### PR TITLE
Add initial configuration for deploying in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,6 @@ executors:
     docker:
       - image: circleci/node:10
 commands:
-  restore_cache_checkout:
-    steps:
-      - restore_cache:
-          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
-
   run_yarn:
     steps:
       - restore_cache:
@@ -23,8 +18,8 @@ commands:
             - ~/.cache/yarn
           key: v1-yarn-{{ .Branch }}
 jobs:
-  # Checks out the repository, and persists to cache.
-  setup:
+  # Deploy website to GitHub Pages
+  deploy:
     executor: node10
     working_directory: ~/upgrade-helper
     steps:
@@ -33,15 +28,9 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/upgrade-helper
-  # Deploy website to GitHub Pages
-  deploy:
-    executor: node10
-    working_directory: ~/upgrade-helper
-    steps:
       - add_ssh_keys:
           fingerprints:
             - '38:fa:ea:6f:43:0d:f8:5d:5c:5c:92:ed:3e:bb:1f:06'
-      - restore_cache_checkout
       - run_yarn
       - run:
           name: Build
@@ -53,7 +42,7 @@ jobs:
               git config --global user.email $GH_EMAIL
               git config --global user.name $GH_NAME
 
-              yarn gh-pages -d build --message "[skip ci] Updates" --repo https://github.com/react-native-community/upgrade-helper.git
+              yarn gh-pages -d build --message "[skip ci] Updates"
             else
               echo "Skipping deploy."
             fi
@@ -61,13 +50,9 @@ workflows:
   # If we are on master, deploy
   deploy:
     jobs:
-      - setup
-      # :
       # filters:
       #   branches:
       #     only:
       #       - master
 
-      - deploy:
-          requires:
-            - setup
+      - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
               git config --global user.email $GH_EMAIL
               git config --global user.name $GH_NAME
 
-              yarn gh-pages -d build --message "[skip ci] Updates"
+              yarn gh-pages -d build --message "[skip ci] Updates" --repo https://$GH_TOKEN@github.com/react-native-community/upgrade-helper.git
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            if [[ $CIRCLE_PROJECT_USERNAME == "react-native-community" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
+            if [[ $CIRCLE_PROJECT_USERNAME == "react-native-community" ]]; then
               git config --global user.email $GH_EMAIL
               git config --global user.name $GH_NAME
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - 'a6:f0:0c:fb:6f:52:09:e2:1c:84:c6:0d:03:23:89:3a'
+            - 'c0:e4:2e:d8:9b:a2:fd:cb:d5:f0:04:df:20:14:a1:4a'
       - restore_cache_checkout
       - run_yarn
       - run:
@@ -53,7 +53,7 @@ jobs:
               git config --global user.email $GH_EMAIL
               git config --global user.name $GH_NAME
 
-              gh-pages -d build --message "[skip ci] Updates"
+              yarn gh-pages -d build --message "[skip ci] Updates"
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
               git config --global user.email $GH_EMAIL
               git config --global user.name $GH_NAME
 
-              yarn gh-pages -d build --message "[skip ci] Updates"
+              yarn gh-pages -d build --message "[skip ci] Updates" --repo https://github.com/react-native-community/upgrade-helper.git
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - 'c0:e4:2e:d8:9b:a2:fd:cb:d5:f0:04:df:20:14:a1:4a'
+            - '38:fa:ea:6f:43:0d:f8:5d:5c:5c:92:ed:3e:bb:1f:06'
       - restore_cache_checkout
       - run_yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+version: 2.1
+executors:
+  node10:
+    docker:
+      - image: circleci/node:10
+commands:
+  restore_cache_checkout:
+    steps:
+      - restore_cache:
+          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+
+  run_yarn:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-yarn-{{ .Branch }}
+      - run:
+          name: yarn install
+          command: yarn install --no-progress --non-interactive --cache-folder ~/.cache/yarn
+      - save_cache:
+          paths:
+            - node_modules
+            - ~/.cache/yarn
+          key: v1-yarn-{{ .Branch }}
+jobs:
+  # Checks out the repository, and persists to cache.
+  setup:
+    executor: node10
+    working_directory: ~/upgrade-helper
+    steps:
+      - checkout
+      - save_cache:
+          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/upgrade-helper
+  # Deploy website to GitHub Pages
+  deploy:
+    executor: node10
+    working_directory: ~/upgrade-helper
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - 'a6:f0:0c:fb:6f:52:09:e2:1c:84:c6:0d:03:23:89:3a'
+      - restore_cache_checkout
+      - run_yarn
+      - run:
+          name: Build
+          command: yarn build
+      - run:
+          name: Deploy
+          command: |
+            if [[ $CIRCLE_PROJECT_USERNAME == "react-native-community" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
+              git config --global user.email $GH_EMAIL
+              git config --global user.name $GH_NAME
+
+              gh-pages -d build --message "[skip ci] Updates"
+            else
+              echo "Skipping deploy."
+            fi
+workflows:
+  # If we are on master, deploy
+  deploy:
+    jobs:
+      - setup:
+          filters:
+            branches:
+              only:
+                - master
+
+      - deploy:
+          requires:
+            - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,12 @@ workflows:
   # If we are on master, deploy
   deploy:
     jobs:
-      - setup:
-          filters:
-            branches:
-              only:
-                - master
+      - setup
+      # :
+      # filters:
+      #   branches:
+      #     only:
+      #       - master
 
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,6 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/upgrade-helper
-      - add_ssh_keys:
-          fingerprints:
-            - '38:fa:ea:6f:43:0d:f8:5d:5c:5c:92:ed:3e:bb:1f:06'
       - run_yarn
       - run:
           name: Build

--- a/package.json
+++ b/package.json
@@ -23,11 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "lint": "eslint . --cache --report-unused-disable-directives",
-    "eject": "react-scripts eject",
-    "predeploy": "yarn build",
-    "deploy": "gh-pages -d build",
-    "deploy-ci": "gh-pages --repo https://$GH_TOKEN@github.com/react-native-community/upgrade-helper.git -d build"
+    "lint": "eslint . --cache --report-unused-disable-directives"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
# Summary

Related to #12.

This PR introduces automatic deploying through CircleCI.

### TODOs

- [x] Fix CircleCI failing when running `gh-pages` (for some reason the SSH key is not being recognized properly)
- [ ] Add filter to only run `deploy` when stuff hits `master` (at least for now)