### PR TITLE
Add useful content section 📣 & binary download ⬇️ button

### DIFF
--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -77,6 +77,7 @@ const Diff = ({
       <DiffHeader
         oldPath={oldPath}
         newPath={newPath}
+        toVersion={toVersion}
         type={type}
         hasDiff={hunks.length > 0}
         isDiffCollapsed={isDiffCollapsed}

--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import semver from 'semver'
-import { versions } from '../../../releases'
-import { removeAppPathPrefix } from '../../../utils'
+import { removeAppPathPrefix, getVersionsInDiff } from '../../../utils'
 import Markdown from '../Markdown'
 
 const Container = styled.div`
@@ -19,22 +17,14 @@ const LINE_CHANGE_TYPES = {
   NEUTRAL: 'N'
 }
 
-const releasedVersions = versions.map(version => ({
-  ...require(`../../../releases/${version}`).default,
-  version
-}))
-
 const getLineNumberWithType = ({ lineChangeType, lineNumber }) =>
   `${LINE_CHANGE_TYPES[lineChangeType.toUpperCase()]}${lineNumber}`
 
 const getComments = ({ newPath, fromVersion, toVersion }) => {
   const newPathSanitized = removeAppPathPrefix(newPath)
-  const cleanedToVersion = semver.valid(semver.coerce(toVersion))
 
-  const versionsInDiff = releasedVersions.filter(
-    ({ version, comments }) =>
-      semver.lte(version, cleanedToVersion) &&
-      semver.gt(version, fromVersion) &&
+  const versionsInDiff = getVersionsInDiff({ fromVersion, toVersion }).filter(
+    ({ comments }) =>
       comments.some(({ fileName }) => fileName === newPathSanitized)
   )
 

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import styled from 'styled-components'
 import { Tag, Icon, Button } from 'antd'
-import { removeAppPathPrefix } from '../../../utils'
+import { removeAppPathPrefix, getBinaryFileURL } from '../../../utils'
 
 const FileRenameArrow = styled(props => <Icon {...props} type="right" />)`
   font-size: 10px;
@@ -57,16 +57,42 @@ const BinaryBadge = ({ visible, ...props }) =>
     </Tag>
   )
 
-const HeaderButtonsContainer = styled(
-  ({ hasDiff, ...props }) => hasDiff && <div {...props} />
-)`
+const HeaderButtonsContainer = styled(props => <div {...props} />)`
   float: right;
 `
 
-const CollapseDiffButton = styled(({ isDiffCollapsed, ...props }) => (
-  <Button {...props} type="link" icon="up" />
-))`
+const DownloadFileButton = styled(
+  ({ visible, toVersion, newPath, ...props }) =>
+    visible && (
+      <Button
+        {...props}
+        type="ghost"
+        shape="circle"
+        icon="download"
+        onClick={() =>
+          (window.location = getBinaryFileURL({
+            version: toVersion,
+            path: newPath
+          }))
+        }
+      />
+    )
+)`
   color: #24292e;
+  font-size: 12px;
+  border-width: 0;
+  &:hover,
+  &:focus {
+    color: #24292e;
+  }
+`
+
+const CollapseDiffButton = styled(
+  ({ visible, isDiffCollapsed, ...props }) =>
+    visible && <Button {...props} type="link" icon="up" />
+)`
+  color: #24292e;
+  margin-right: 2px;
   font-size: 10px;
   transform: ${({ isDiffCollapsed }) =>
     isDiffCollapsed ? 'rotate(-180deg)' : 'initial'};
@@ -84,6 +110,7 @@ const DiffHeader = styled(
   ({
     oldPath,
     newPath,
+    toVersion,
     type,
     hasDiff,
     isDiffCollapsed,
@@ -94,11 +121,19 @@ const DiffHeader = styled(
       <FileName oldPath={oldPath} newPath={newPath} type={type} />{' '}
       <FileStatus type={type} />
       <BinaryBadge visible={!hasDiff} />
-      <HeaderButtonsContainer hasDiff={hasDiff}>
-        <CollapseDiffButton
-          isDiffCollapsed={isDiffCollapsed}
-          onClick={() => setIsDiffCollapsed(!isDiffCollapsed)}
-        />
+      <HeaderButtonsContainer>
+        <Fragment>
+          <DownloadFileButton
+            visible={!hasDiff}
+            toVersion={toVersion}
+            newPath={newPath}
+          />
+          <CollapseDiffButton
+            visible={hasDiff}
+            isDiffCollapsed={isDiffCollapsed}
+            onClick={() => setIsDiffCollapsed(!isDiffCollapsed)}
+          />
+        </Fragment>
       </HeaderButtonsContainer>
     </div>
   )

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -5,6 +5,7 @@ import 'react-diff-view/style/index.css'
 import { getDiffPatchURL } from '../../utils'
 import Diff from './Diff/Diff'
 import Loading from './Loading'
+import UsefulContentSection from './UsefulContentSection'
 
 const Container = styled.div`
   width: 90%;
@@ -54,6 +55,8 @@ const DiffViewer = ({
 
   return (
     <Container>
+      <UsefulContentSection fromVersion={fromVersion} toVersion={toVersion} />
+
       {diff.map(diff => (
         <Diff
           key={`${diff.oldRevision}${diff.newRevision}`}

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -2,15 +2,13 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { parseDiff, withChangeSelect } from 'react-diff-view'
 import 'react-diff-view/style/index.css'
+import { getDiffPatchURL } from '../../utils'
 import Diff from './Diff/Diff'
 import Loading from './Loading'
 
 const Container = styled.div`
   width: 90%;
 `
-
-const getPatchURL = ({ fromVersion, toVersion }) =>
-  `https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/${fromVersion}..${toVersion}.diff`
 
 const DiffViewer = ({
   showDiff,
@@ -31,7 +29,7 @@ const DiffViewer = ({
       setLoading(true)
 
       const response = await (await fetch(
-        getPatchURL({ fromVersion, toVersion })
+        getDiffPatchURL({ fromVersion, toVersion })
       )).text()
 
       setDiff(

--- a/src/components/common/Markdown.js
+++ b/src/components/common/Markdown.js
@@ -2,8 +2,10 @@ import React from 'react'
 import Markdown from 'markdown-to-jsx'
 import styled from 'styled-components'
 
-// eslint-disable-next-line jsx-a11y/anchor-has-content
-const Link = styled(props => <a target="_blank" {...props} rel="noopener" />)`
+export const Link = styled(props => (
+  // eslint-disable-next-line jsx-a11y/anchor-has-content
+  <a target="_blank" {...props} rel="noopener" />
+))`
   text-decoration: none;
   color: #045dc1;
 `

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -1,0 +1,100 @@
+import React, { useState, Fragment } from 'react'
+import styled from 'styled-components'
+import { Button } from 'antd'
+import { getVersionsInDiff } from '../../utils'
+import { Link } from './Markdown'
+
+const Container = styled.div`
+  position: relative;
+  margin-top: 16px;
+  color: rgba(0, 0, 0, 0.65);
+  max-height: ${({ isVisible }) => (isVisible ? '500px' : 0)}
+  overflow: hidden;
+  transition: max-height 0.4s ease-out;
+`
+
+const InnerContainer = styled.div`
+  padding: 24px;
+  color: rgba(0, 0, 0, 0.65);
+  border: 1px solid #e8e8e8;
+  border-radius: 3px;
+`
+
+const Icon = styled(props => (
+  <span {...props} role="img" aria-label="Close useful content section">
+    📣
+  </span>
+))`
+  margin: 0px 10px;
+`
+
+const CloseButton = styled(({ isVisible, setVisibility, ...props }) => (
+  <Button
+    {...props}
+    type="ghost"
+    shape="circle"
+    icon="close"
+    onClick={() => setVisibility(!isVisible)}
+  />
+))`
+  float: right;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 12px;
+  border-width: 0px;
+  width: 20px;
+  height: 20px;
+  padding-right: 8px;
+  &,
+  &:hover,
+  &:focus {
+    color: #24292e;
+  }
+`
+
+const List = styled.ol`
+  padding-inline-start: 18px;
+  margin: 10px 0 0;
+`
+
+const UsefulContentSection = ({ fromVersion, toVersion }) => {
+  const [isVisible, setVisibility] = useState(true)
+
+  const versions = getVersionsInDiff({ fromVersion, toVersion })
+  const doesAnyVersionHaveUsefulContent = versions.some(
+    ({ usefulContent }) => !!usefulContent
+  )
+
+  if (!doesAnyVersionHaveUsefulContent) {
+    return null
+  }
+
+  return (
+    <Container isVisible={isVisible}>
+      <InnerContainer>
+        <h2>
+          <Icon /> Useful content for upgrading
+        </h2>
+
+        <CloseButton isVisible={isVisible} setVisibility={setVisibility} />
+
+        {versions.map(({ usefulContent }, key) => (
+          <Fragment key={key}>
+            <span>{usefulContent.description}</span>
+
+            <List>
+              {usefulContent.links.map(({ url, title }, key) => (
+                <li key={`${url}${key}`}>
+                  <Link href={url}>{title}</Link>
+                </li>
+              ))}
+            </List>
+          </Fragment>
+        ))}
+      </InnerContainer>
+    </Container>
+  )
+}
+
+export default UsefulContentSection

--- a/src/releases/0.60.0.js
+++ b/src/releases/0.60.0.js
@@ -1,6 +1,19 @@
 import React, { Fragment } from 'react'
 
 export default {
+  usefulContent: {
+    description: 'This is a description of the useful content section.',
+    links: [
+      {
+        title: 'Nice upgrade link',
+        url: 'https://github.com/react-native-community/upgrade-helper'
+      },
+      {
+        title: 'Another nice upgrade link',
+        url: 'https://github.com/react-native-community/upgrade-helper/issues'
+      }
+    ]
+  },
   comments: [
     {
       fileName: 'package.json',

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,10 @@ export const RELEASES_URL = `https://raw.githubusercontent.com/${RN_DIFF_REPO}/m
 export const getDiffPatchURL = ({ fromVersion, toVersion }) =>
   `https://raw.githubusercontent.com/${RN_DIFF_REPO}/diffs/diffs/${fromVersion}..${toVersion}.diff`
 
+// `path` must contain `RnDiffApp` prefix
+export const getBinaryFileURL = ({ version, path }) =>
+  `https://github.com/${RN_DIFF_REPO}/raw/release/${version}/${path}`
+
 export const removeAppPathPrefix = path => path.replace(/RnDiffApp\//, '')
 
 export const getVersionsInDiff = ({ fromVersion, toVersion }) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,21 @@
+import semver from 'semver'
+import { versions } from './releases'
+
+const releasedVersions = versions.map(version => ({
+  ...require(`./releases/${version}`).default,
+  version
+}))
+
 export const RELEASES_URL =
   'https://raw.githubusercontent.com/react-native-community/rn-diff-purge/master/RELEASES'
 
 export const removeAppPathPrefix = path => path.replace(/RnDiffApp\//, '')
+
+export const getVersionsInDiff = ({ fromVersion, toVersion }) => {
+  const cleanedToVersion = semver.valid(semver.coerce(toVersion))
+
+  return releasedVersions.filter(
+    ({ version }) =>
+      semver.lte(version, cleanedToVersion) && semver.gt(version, fromVersion)
+  )
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,17 @@
 import semver from 'semver'
 import { versions } from './releases'
 
+const RN_DIFF_REPO = 'react-native-community/rn-diff-purge'
+
 const releasedVersions = versions.map(version => ({
   ...require(`./releases/${version}`).default,
   version
 }))
 
-export const RELEASES_URL =
-  'https://raw.githubusercontent.com/react-native-community/rn-diff-purge/master/RELEASES'
+export const RELEASES_URL = `https://raw.githubusercontent.com/${RN_DIFF_REPO}/master/RELEASES`
+
+export const getDiffPatchURL = ({ fromVersion, toVersion }) =>
+  `https://raw.githubusercontent.com/${RN_DIFF_REPO}/diffs/diffs/${fromVersion}..${toVersion}.diff`
 
 export const removeAppPathPrefix = path => path.replace(/RnDiffApp\//, '')
 


### PR DESCRIPTION
⚠️ **NOT MERGEABLE YET** ⚠️ 

Need to remove the `0.60.0` changes.

# Summary

This PR adds a section on top of the diff to gather useful info and links for the user to help out on the upgrade & a button to download binary files.

Related to #10.
Fixes #22.

It's implemented with a dismiss button.

---

![Kapture 2019-06-11 at 22 37 47](https://user-images.githubusercontent.com/6207220/59305069-c38a0c80-8c99-11e9-8b9a-4af1e5585c69.gif)

---

<img width="1058" alt="Screenshot 2019-06-11 at 22 38 09" src="https://user-images.githubusercontent.com/6207220/59305084-ca188400-8c99-11e9-945c-28bb5e90b3b3.png">

---

<img width="812" alt="Screenshot 2019-06-11 at 22 47 35" src="https://user-images.githubusercontent.com/6207220/59305670-ff71a180-8c9a-11e9-8842-29285baa5037.png">

