### PR TITLE
Add content for more versions + GitHub button + Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^16.8.0",
     "react-diff-view": "^2.1.3",
     "react-dom": "^16.8.0",
+    "react-ga": "^2.5.7",
     "react-github-btn": "^1.0.0",
     "react-scripts": "3.0.1",
     "semver": "^6.0.0",

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -69,7 +69,7 @@ const DiffViewer = ({
 
   return (
     <Container>
-      <UsefulContentSection fromVersion={fromVersion} toVersion={toVersion} />
+      <UsefulContentSection isLoading={isLoading} fromVersion={fromVersion} toVersion={toVersion} />
 
       {diff.map(diff => {
         const diffKey = getDiffKey(diff)

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -8,7 +8,7 @@ const Container = styled.div`
   position: relative;
   margin-top: 16px;
   color: rgba(0, 0, 0, 0.65);
-  max-height: ${({ isVisible }) => (isVisible ? '500px' : 0)}
+  max-height: ${({ isVisible }) => (isVisible ? '800px' : 0)}
   overflow: hidden;
   transition: max-height 0.4s ease-out;
 `

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react'
 import styled from 'styled-components'
 import { Button } from 'antd'
-import { getVersionsInDiff } from '../../utils'
+import { getVersionsInDiff, getChangelogURL } from '../../utils'
 import { Link } from './Markdown'
 
 const Container = styled.div`
@@ -53,6 +53,13 @@ const CloseButton = styled(({ isVisible, setVisibility, ...props }) => (
   }
 `
 
+const ReleaseSeparator = styled.hr`
+  margin: 15px 0;
+  background-color: #e1e4e8;
+  height: 0.25em;
+  border: 0;
+`
+
 const List = styled.ol`
   padding-inline-start: 18px;
   margin: 10px 0 0;
@@ -70,6 +77,8 @@ const UsefulContentSection = ({ fromVersion, toVersion }) => {
     return null
   }
 
+  const hasMoreThanOneRelease = versions.length > 1
+
   return (
     <Container isVisible={isVisible}>
       <InnerContainer>
@@ -79,19 +88,37 @@ const UsefulContentSection = ({ fromVersion, toVersion }) => {
 
         <CloseButton isVisible={isVisible} setVisibility={setVisibility} />
 
-        {versions.map(({ usefulContent }, key) => (
-          <Fragment key={key}>
-            <span>{usefulContent.description}</span>
+        {versions.map(({ usefulContent, version }, key) => {
+          const versionWithoutEndingZero = version.slice(0, 4)
 
-            <List>
-              {usefulContent.links.map(({ url, title }, key) => (
-                <li key={`${url}${key}`}>
-                  <Link href={url}>{title}</Link>
-                </li>
-              ))}
-            </List>
-          </Fragment>
-        ))}
+          const links = [
+            ...usefulContent.links,
+            {
+              title: `React Native ${versionWithoutEndingZero} changelog`,
+              url: getChangelogURL({ version: versionWithoutEndingZero })
+            }
+          ]
+
+          return (
+            <Fragment key={key}>
+              {key > 0 && <ReleaseSeparator />}
+
+              {hasMoreThanOneRelease && (
+                <h3>Release {versionWithoutEndingZero}</h3>
+              )}
+
+              <span>{usefulContent.description}</span>
+
+              <List>
+                {links.map(({ url, title }, key) => (
+                  <li key={`${url}${key}`}>
+                    <Link href={url}>{title}</Link>
+                  </li>
+                ))}
+              </List>
+            </Fragment>
+          )
+        })}
       </InnerContainer>
     </Container>
   )

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -137,8 +137,6 @@ const VersionSelector = ({ showDiff }) => {
 
   return (
     <Fragment>
-      <h1>React Native update guide</h1>
-
       <Selectors>
         <FromVersionSelector
           title="What's your current React Native version?"

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { Card } from 'antd'
 import GitHubButton from 'react-github-btn'
+import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
 
@@ -36,6 +37,13 @@ const Home = () => {
   const [fromVersion, setFromVersion] = useState('')
   const [toVersion, setToVersion] = useState('')
   const [showDiff, setShowDiff] = useState(false)
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      ReactGA.initialize('UA-136307971-1')
+      ReactGA.pageview('/')
+    }
+  }, [])
 
   const handleShowDiff = ({ fromVersion, toVersion }) => {
     setFromVersion(fromVersion)

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -5,6 +5,7 @@ import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
+import { homepage } from '../../../package.json'
 
 const Page = styled.div`
   display: flex;
@@ -55,7 +56,7 @@ const Home = () => {
     <Page>
       <Container>
         <TitleContainer>
-          <h1>React Native upgrade guide</h1>
+          <a href={homepage}><h1>React Native upgrade guide</h1></a>
 
           <StarButton
             href="https://github.com/react-native-community/upgrade-helper"

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Card } from 'antd'
+import GitHubButton from 'react-github-btn'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
 
@@ -17,6 +18,20 @@ const Container = styled(Card)`
   border-radius: 3px;
 `
 
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const StarButton = styled(({ className, ...props }) => (
+  <div className={className}>
+    <GitHubButton {...props} />
+  </div>
+))`
+  margin-bottom: 5px;
+  margin-left: 15px;
+`
+
 const Home = () => {
   const [fromVersion, setFromVersion] = useState('')
   const [toVersion, setToVersion] = useState('')
@@ -31,6 +46,19 @@ const Home = () => {
   return (
     <Page>
       <Container>
+        <TitleContainer>
+          <h1>React Native upgrade guide</h1>
+
+          <StarButton
+            href="https://github.com/react-native-community/upgrade-helper"
+            data-icon="octicon-star"
+            data-show-count="true"
+            aria-label="Star react-native-community/upgrade-helper on GitHub"
+          >
+            Star
+          </StarButton>
+        </TitleContainer>
+
         <VersionSelector showDiff={handleShowDiff} />
       </Container>
 

--- a/src/releases/0.57.0.js
+++ b/src/releases/0.57.0.js
@@ -8,11 +8,6 @@ export default {
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.57/'
       }
-      // {
-      //   title: 'React Native 0.59 changelog',
-      //   url:
-      //     'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#059'
-      // }
     ]
   }
 }

--- a/src/releases/0.57.0.js
+++ b/src/releases/0.57.0.js
@@ -1,0 +1,18 @@
+export default {
+  usefulContent: {
+    description:
+      'React Native 0.57 includes 599 commits by 73 different contributors, it has improvements to Accessibility APIs, Babel 7 stable support and more.',
+    links: [
+      {
+        title: 'Tutorial on upgrading to React Native 0.57',
+        url:
+          'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.57/'
+      }
+      // {
+      //   title: 'React Native 0.59 changelog',
+      //   url:
+      //     'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#059'
+      // }
+    ]
+  }
+}

--- a/src/releases/0.58.0.js
+++ b/src/releases/0.58.0.js
@@ -8,11 +8,6 @@ export default {
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.58/'
       }
-      // {
-      //   title: 'React Native 0.59 changelog',
-      //   url:
-      //     'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#059'
-      // }
     ]
   }
 }

--- a/src/releases/0.58.0.js
+++ b/src/releases/0.58.0.js
@@ -1,0 +1,18 @@
+export default {
+  usefulContent: {
+    description:
+      'React Native 0.58 is the first release of 2019, it includes work for modernizing and strengthening flow types for core components and  numerous crash fixes and resolutions for unexpected behaviors.',
+    links: [
+      {
+        title: 'Tutorial on upgrading to React Native 0.58',
+        url:
+          'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.58/'
+      }
+      // {
+      //   title: 'React Native 0.59 changelog',
+      //   url:
+      //     'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#059'
+      // }
+    ]
+  }
+}

--- a/src/releases/0.59.0.js
+++ b/src/releases/0.59.0.js
@@ -1,18 +1,18 @@
 export default {
   usefulContent: {
-    description: 'React Native 0.59 includes React Hooks, performance gains on Android and lots of cool stuff.',
+    description:
+      'React Native 0.59 includes React Hooks, performance gains on Android and lots of cool stuff.',
     links: [
       {
-        title: 'Official blog post about the major changes on React Native 0.59',
-        url: 'https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059'
+        title:
+          'Official blog post about the major changes on React Native 0.59',
+        url:
+          'https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059'
       },
       {
         title: 'Tutorial on upgrading to React Native 0.59',
-        url: 'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.59/'
-      },
-      {
-        title: 'React Native 0.59 changelog',
-        url: 'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#059'
+        url:
+          'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.59/'
       }
     ]
   }

--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -1,1 +1,1 @@
-export const versions = ['0.59.0']
+export const versions = ['0.59.0', '0.58.0', '0.57.0']

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,3 +27,9 @@ export const getVersionsInDiff = ({ fromVersion, toVersion }) => {
       semver.lte(version, cleanedToVersion) && semver.gt(version, fromVersion)
   )
 }
+
+export const getChangelogURL = ({ version }) =>
+  `https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#${version.replace(
+    '.',
+    ''
+  )}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -8875,6 +8875,11 @@ react-error-overlay@^5.1.6:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
+react-ga@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.5.7.tgz#1c80a289004bf84f84c26d46f3a6a6513081bf2e"
+  integrity sha512-UmATFaZpEQDO96KFjB5FRLcT6hFcwaxOmAJZnjrSiFN/msTqylq9G+z5Z8TYzN/dbamDTiWf92m6MnXXJkAivQ==
+
 react-github-btn@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-github-btn/-/react-github-btn-1.0.5.tgz#03ee7c6cd51f04ef940543b5ec247fbe4fe09a05"


### PR DESCRIPTION
# Summary

This PR fixes #14, #15, #29 & #31.

What it does:

- Add useful content section for `0.57`, `0.58` and `0.59`;
- Show a link to the react-native changelog automatically;
- Have a better UI for showing multiple useful content section for each version;
- Add GitHub star button;
- Add analytics back.

### Multiple versions upgrade

![image](https://user-images.githubusercontent.com/6207220/59460674-f3631c80-8e1f-11e9-985e-2d225ab0eac9.png)

### Single version upgrade

![image](https://user-images.githubusercontent.com/6207220/59460712-0a097380-8e20-11e9-818f-ee249993d897.png)

