### PR TITLE
feat: add completed files counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^16.8.0",
     "react-diff-view": "^2.1.3",
     "react-dom": "^16.8.0",
+    "react-dom-confetti": "^0.1.1",
     "react-ga": "^2.5.7",
     "react-github-btn": "^1.0.0",
     "react-scripts": "3.0.1",

--- a/src/components/common/CompletedFilesCounter.js
+++ b/src/components/common/CompletedFilesCounter.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import styled, { keyframes, css } from 'styled-components'
+import Confetti from 'react-dom-confetti'
+
+const shake = keyframes`
+  0% {
+    transform: translate(0, 0);
+  }
+
+  10%, 90% {
+    transform: translate(0, -2px);
+  }
+  
+  20%, 80% {
+    transform: translate(0, 3px);
+  }
+
+  30%, 50%, 70% {
+    transform: translate(0, -5px);
+  }
+
+  40%, 60% {
+    transform: translate(0, 5px);
+  }
+`
+
+const CompletedFilesCounter = styled(({ completed, total, ...props }) => (
+  <div {...props}>
+    <span className="completedAmount">{completed === 0 ? 1 : completed}</span> /
+    {total}
+    <Confetti
+      active={completed === total}
+      config={{
+        elementCount: 200,
+        angle: 130,
+        startVelocity: 30
+      }}
+    />
+  </div>
+))`
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #d5eafd;
+  padding: 10px;
+  border: 1px solid #1890ff;
+  border-radius: 20px;
+  color: #7dadda;
+  transform: ${({ completed }) =>
+    completed ? 'translateY(0px)' : 'translateY(70px)'};
+  width: fit-content;
+  height: fit-content;
+  display: flex;
+  align-self: flex-end;
+  transition: transform 0.3s;
+  ${({ completed, total }) =>
+    completed === total &&
+    css`
+      transform: translateY(70px);
+      animation: ${shake};
+      animation-duration: 1.5s;
+    `}
+
+  .completedAmount {
+    color: #1890ff;
+  }
+`
+
+export default CompletedFilesCounter

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -6,6 +6,7 @@ import { getDiffPatchURL } from '../../utils'
 import Diff from './Diff/Diff'
 import Loading from './Loading'
 import UsefulContentSection from './UsefulContentSection'
+import CompletedFilesCounter from './CompletedFilesCounter'
 
 const Container = styled.div`
   width: 90%;
@@ -35,6 +36,8 @@ const DiffViewer = ({
     setCompletedDiffs(prevCompletedDiffs => [...prevCompletedDiffs, diffKey])
   }
 
+  const resetCompletedDiff = () => setCompletedDiffs([])
+
   useEffect(() => {
     if (!showDiff) {
       return
@@ -53,6 +56,8 @@ const DiffViewer = ({
         )
       )
 
+      resetCompletedDiff()
+
       setLoading(false)
     }
 
@@ -69,7 +74,11 @@ const DiffViewer = ({
 
   return (
     <Container>
-      <UsefulContentSection isLoading={isLoading} fromVersion={fromVersion} toVersion={toVersion} />
+      <UsefulContentSection
+        isLoading={isLoading}
+        fromVersion={fromVersion}
+        toVersion={toVersion}
+      />
 
       {diff.map(diff => {
         const diffKey = getDiffKey(diff)
@@ -78,7 +87,7 @@ const DiffViewer = ({
           <Diff
             key={`${diff.oldRevision}${diff.newRevision}`}
             {...diff}
-             // otakustay/react-diff-view#49
+            // otakustay/react-diff-view#49
             type={diff.type === 'new' ? 'add' : diff.type}
             diffKey={diffKey}
             fromVersion={fromVersion}
@@ -90,6 +99,11 @@ const DiffViewer = ({
           />
         )
       })}
+
+      <CompletedFilesCounter
+        completed={completedDiffs.length}
+        total={diff.length}
+      />
     </Container>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3544,6 +3544,11 @@ dom-closest@^0.2.0:
   dependencies:
     dom-matches ">=1.0.1"
 
+dom-confetti@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-confetti/-/dom-confetti-0.1.1.tgz#f53c355301286430e9f500567adac5041c827468"
+  integrity sha512-cyTs35FOqOlm+9rC8C5p0BFo0aHR2t6VWHdXmvgUEFHsF/P7tZeS5nw71oX6NifJrlxOmZ6VcmCH/hn99mqaAA==
+
 dom-converter@^0.2:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -8892,6 +8897,13 @@ react-diff-view@^2.1.3:
     recompose "^0.30.0"
     shallow-equal "^1.0.0"
     warning "^4.0.2"
+
+react-dom-confetti@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/react-dom-confetti/-/react-dom-confetti-0.1.1.tgz#f9d611110413faed8da72de1f47fbce78df637b9"
+  integrity sha512-QT2orDvHChdhIUU7HZtx0kiEMiBtZKDfPqzfoku7bftvLM5t7d1fbQX0JO8sw+tDVWJFgceNJtkq6bv9V/eXQQ==
+  dependencies:
+    dom-confetti "0.1.1"
 
 react-dom@^16.8.0:
   version "16.8.6"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR fixes #30, it adds a counter to the bottom right of the page showing how many files have been completed and how many are left, the counter only shows when you actually complete a file and it has a confetti animation that is triggered when you completed all of them.

## Test Plan

1. Run the PR locally;
1. Open http://localhost:3000/?from=0.59.8&to=0.59.9;
1. Complete files.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)

---

![counter](https://user-images.githubusercontent.com/6207220/60419929-c0be6f80-9be6-11e9-9858-508fb84339bb.gif)
