### PR TITLE
Counter style looks different on Safari 

### DIFF
--- a/src/components/common/CompletedFilesCounter.js
+++ b/src/components/common/CompletedFilesCounter.js
@@ -48,8 +48,6 @@ const CompletedFilesCounter = styled(({ completed, total, ...props }) => (
   color: #7dadda;
   transform: ${({ completed }) =>
     completed ? 'translateY(0px)' : 'translateY(70px)'};
-  width: fit-content;
-  height: fit-content;
   display: flex;
   align-self: flex-end;
   transition: transform 0.3s;


### PR DESCRIPTION
# Summary
Counter style look different on the Safari browser.
It seem that `fit-content` doesn't went well on Safari.
This fix #51.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

1. Run the PR locally
2. Open http://localhost:3000/?from=0.59.10&to=0.60.0 on Safari
3. Click check on the files

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I tested on Safari
- [x] I tested on Chrome
- [x] I tested on Firefox
- [x] I added the documentation in `README.md` (if needed)

<img width="180" alt="螢幕快照 2019-07-05 上午2 33 59" src="https://user-images.githubusercontent.com/7204070/60684044-138d7500-9ece-11e9-83c1-2f992b7f939e.png">
<img width="131" alt="螢幕快照 2019-07-05 上午2 33 24" src="https://user-images.githubusercontent.com/7204070/60684048-15573880-9ece-11e9-8bce-5c99c1f783a9.png">
<img width="197" alt="螢幕快照 2019-07-05 上午2 31 30" src="https://user-images.githubusercontent.com/7204070/60684050-18eabf80-9ece-11e9-9c57-b24cb8ae4d9e.png">
