### PR TITLE
feat: implement new logo

### DIFF
--- a/src/__tests__/__snapshots__/App.spec.js.snap
+++ b/src/__tests__/__snapshots__/App.spec.js.snap
@@ -14,15 +14,23 @@ exports[`renders without crashing 1`] = `
         <div
           class="sc-kEYyzF fEebBv"
         >
+          <img
+            alt="React Native upgrade helper logo"
+            class="sc-kkGfuU kCopwy"
+            src="logo.svg"
+            title="React Native upgrade helper logo"
+          />
           <a
             href="https://react-native-community.github.io/upgrade-helper"
           >
-            <h1>
+            <h1
+              class="sc-iAyFgw ixxwvO"
+            >
               React Native upgrade guide
             </h1>
           </a>
           <div
-            class="sc-kkGfuU emfoKJ"
+            class="sc-hSdWYo inYTmX"
           >
             <div>
               ReactGitHubBtn - 

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -6,6 +6,7 @@ import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
 import { homepage } from '../../../package.json'
+import logo from '../../logo.svg'
 
 const Page = styled.div`
   display: flex;
@@ -25,12 +26,21 @@ const TitleContainer = styled.div`
   align-items: center;
 `
 
+const LogoImg = styled.img`
+  width: 100px;
+`
+
+const TitleHeader = styled.h1`
+  margin: 0;
+  margin-left: 15px;
+`
+
 const StarButton = styled(({ className, ...props }) => (
   <div className={className}>
     <GitHubButton {...props} />
   </div>
 ))`
-  margin-bottom: 5px;
+  margin-top: 10px;
   margin-left: 15px;
 `
 
@@ -60,7 +70,15 @@ const Home = () => {
     <Page>
       <Container>
         <TitleContainer>
-          <a href={homepage}><h1>React Native upgrade guide</h1></a>
+          <LogoImg
+            alt="React Native upgrade helper logo"
+            title="React Native upgrade helper logo"
+            src={logo}
+          />
+
+          <a href={homepage}>
+            <TitleHeader>React Native upgrade guide</TitleHeader>
+          </a>
 
           <StarButton
             href="https://github.com/react-native-community/upgrade-helper"

--- a/src/logo.svg
+++ b/src/logo.svg
@@ -1,7 +1,73 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 841.9 595.3">
-    <g fill="#61DAFB">
-        <path d="M666.3 296.5c0-32.5-40.7-63.3-103.1-82.4 14.4-63.6 8-114.2-20.2-130.4-6.5-3.8-14.1-5.6-22.4-5.6v22.3c4.6 0 8.3.9 11.4 2.6 13.6 7.8 19.5 37.5 14.9 75.7-1.1 9.4-2.9 19.3-5.1 29.4-19.6-4.8-41-8.5-63.5-10.9-13.5-18.5-27.5-35.3-41.6-50 32.6-30.3 63.2-46.9 84-46.9V78c-27.5 0-63.5 19.6-99.9 53.6-36.4-33.8-72.4-53.2-99.9-53.2v22.3c20.7 0 51.4 16.5 84 46.6-14 14.7-28 31.4-41.3 49.9-22.6 2.4-44 6.1-63.6 11-2.3-10-4-19.7-5.2-29-4.7-38.2 1.1-67.9 14.6-75.8 3-1.8 6.9-2.6 11.5-2.6V78.5c-8.4 0-16 1.8-22.6 5.6-28.1 16.2-34.4 66.7-19.9 130.1-62.2 19.2-102.7 49.9-102.7 82.3 0 32.5 40.7 63.3 103.1 82.4-14.4 63.6-8 114.2 20.2 130.4 6.5 3.8 14.1 5.6 22.5 5.6 27.5 0 63.5-19.6 99.9-53.6 36.4 33.8 72.4 53.2 99.9 53.2 8.4 0 16-1.8 22.6-5.6 28.1-16.2 34.4-66.7 19.9-130.1 62-19.1 102.5-49.9 102.5-82.3zm-130.2-66.7c-3.7 12.9-8.3 26.2-13.5 39.5-4.1-8-8.4-16-13.1-24-4.6-8-9.5-15.8-14.4-23.4 14.2 2.1 27.9 4.7 41 7.9zm-45.8 106.5c-7.8 13.5-15.8 26.3-24.1 38.2-14.9 1.3-30 2-45.2 2-15.1 0-30.2-.7-45-1.9-8.3-11.9-16.4-24.6-24.2-38-7.6-13.1-14.5-26.4-20.8-39.8 6.2-13.4 13.2-26.8 20.7-39.9 7.8-13.5 15.8-26.3 24.1-38.2 14.9-1.3 30-2 45.2-2 15.1 0 30.2.7 45 1.9 8.3 11.9 16.4 24.6 24.2 38 7.6 13.1 14.5 26.4 20.8 39.8-6.3 13.4-13.2 26.8-20.7 39.9zm32.3-13c5.4 13.4 10 26.8 13.8 39.8-13.1 3.2-26.9 5.9-41.2 8 4.9-7.7 9.8-15.6 14.4-23.7 4.6-8 8.9-16.1 13-24.1zM421.2 430c-9.3-9.6-18.6-20.3-27.8-32 9 .4 18.2.7 27.5.7 9.4 0 18.7-.2 27.8-.7-9 11.7-18.3 22.4-27.5 32zm-74.4-58.9c-14.2-2.1-27.9-4.7-41-7.9 3.7-12.9 8.3-26.2 13.5-39.5 4.1 8 8.4 16 13.1 24 4.7 8 9.5 15.8 14.4 23.4zM420.7 163c9.3 9.6 18.6 20.3 27.8 32-9-.4-18.2-.7-27.5-.7-9.4 0-18.7.2-27.8.7 9-11.7 18.3-22.4 27.5-32zm-74 58.9c-4.9 7.7-9.8 15.6-14.4 23.7-4.6 8-8.9 16-13 24-5.4-13.4-10-26.8-13.8-39.8 13.1-3.1 26.9-5.8 41.2-7.9zm-90.5 125.2c-35.4-15.1-58.3-34.9-58.3-50.6 0-15.7 22.9-35.6 58.3-50.6 8.6-3.7 18-7 27.7-10.1 5.7 19.6 13.2 40 22.5 60.9-9.2 20.8-16.6 41.1-22.2 60.6-9.9-3.1-19.3-6.5-28-10.2zM310 490c-13.6-7.8-19.5-37.5-14.9-75.7 1.1-9.4 2.9-19.3 5.1-29.4 19.6 4.8 41 8.5 63.5 10.9 13.5 18.5 27.5 35.3 41.6 50-32.6 30.3-63.2 46.9-84 46.9-4.5-.1-8.3-1-11.3-2.7zm237.2-76.2c4.7 38.2-1.1 67.9-14.6 75.8-3 1.8-6.9 2.6-11.5 2.6-20.7 0-51.4-16.5-84-46.6 14-14.7 28-31.4 41.3-49.9 22.6-2.4 44-6.1 63.6-11 2.3 10.1 4.1 19.8 5.2 29.1zm38.5-66.7c-8.6 3.7-18 7-27.7 10.1-5.7-19.6-13.2-40-22.5-60.9 9.2-20.8 16.6-41.1 22.2-60.6 9.9 3.1 19.3 6.5 28.1 10.2 35.4 15.1 58.3 34.9 58.3 50.6-.1 15.7-23 35.6-58.4 50.6zM320.8 78.4z"/>
-        <circle cx="420.9" cy="296.5" r="45.7"/>
-        <path d="M520.5 78.1z"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="523px" height="470px" viewBox="0 0 523 470" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>BlueprintLogo</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M95.5723101,7 L491,7 L491,477 L366.926937,477 L253.620642,280.747742 C266.429251,273.05556 275,259.028683 275,243 C275,218.699471 255.300529,199 231,199 C223.239964,199 215.949123,201.008864 209.61915,204.534921 L95.5723101,7 Z" id="path-1"></path>
+        <circle id="path-3" cx="231" cy="243" r="44"></circle>
+        <mask id="mask-4" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="88" height="88" fill="white">
+            <use xlink:href="#path-3"></use>
+        </mask>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Blueprint-w/-Background" transform="translate(0.000000, -7.000000)">
+            <g id="Group-5" transform="translate(32.000000, 0.000000)">
+                <g id="Group-4" fill-rule="nonzero">
+                    <ellipse id="Oval" stroke="#00D8FF" stroke-width="23" transform="translate(229.500000, 241.500000) rotate(90.000000) translate(-229.500000, -241.500000) " cx="229.5" cy="241.5" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#00D8FF" stroke-width="23" transform="translate(229.500000, 242.500000) rotate(30.000000) translate(-229.500000, -242.500000) " cx="229.5" cy="242.5" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#00D8FF" stroke-width="23" transform="translate(229.661197, 242.002830) rotate(-30.000000) translate(-229.661197, -242.002830) " cx="229.661197" cy="242.00283" rx="86.5" ry="229.5"></ellipse>
+                    <circle id="Oval-2" fill="#00D8FF" cx="231" cy="244" r="44"></circle>
+                </g>
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <g id="Combined-Shape" fill-rule="nonzero"></g>
+                <g id="Lines" mask="url(#mask-2)" stroke-dasharray="2,8" stroke-linecap="square">
+                    <g transform="translate(60.000000, -4.000000)">
+                        <g id="H-Lines" transform="translate(65.000000, 0.000000)">
+                            <path d="M351,0 L351,488" id="Line" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M316,0 L316,488" id="Line-Copy-8" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M281.25,0 L281.25,488" id="Line-Copy-7" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M246,0 L246,488" id="Line" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M211,0 L211,488" id="Line-Copy-6" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M176,0 L176,488" id="Line-Copy-5" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M176,0 L176,488" id="Line-Copy-4" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M141,0 L141,488" id="Line-Copy-3" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M106,0 L106,488" id="Line-Copy-2" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M71,0 L71,488" id="Line" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M36,0 L36,488" id="Line" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M1,0 L1,488" id="Line-Copy" stroke="#00D8FF" stroke-width="2.5"></path>
+                        </g>
+                        <g id="V-Lines" transform="translate(224.500000, 248.500000) rotate(90.000000) translate(-224.500000, -248.500000) translate(-4.000000, 24.000000)">
+                            <path d="M421.5,449 L421.5,0.5" id="Line-2-Copy-5" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M456.5,449 L456.5,0.5" id="Line-2-Copy-12" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M386.5,449 L386.5,0.5" id="Line-2-Copy-11" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M351.5,449 L351.5,0.5" id="Line-2-Copy-10" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M316.5,449 L316.5,0.5" id="Line-2-Copy-9" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M280.5,449 L281.5,0.5" id="Line-2-Copy-8" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M245.5,449 L245.5,0.5" id="Line-2-Copy-7" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M210.5,449 L210.5,0.5" id="Line-2-Copy-6" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M175.5,449 L175.5,0.5" id="Line-2-Copy-4" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M140.5,449 L140.5,0.5" id="Line-2-Copy-3" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M105.5,449 L105.5,0.5" id="Line-2-Copy-2" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M70.5,449 L70.5,0.5" id="Line-2-Copy" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M35.5,449 L35.5,0.5" id="Line-2" stroke="#00D8FF" stroke-width="2.5"></path>
+                            <path d="M0.5,449 L0.5,0.5" id="Line-2" stroke="#00D8FF" stroke-width="2.5"></path>
+                        </g>
+                    </g>
+                </g>
+                <g id="Group-3" mask="url(#mask-2)" fill-rule="nonzero">
+                    <ellipse id="Oval" stroke="#00D8FF" stroke-width="23" transform="translate(229.500000, 241.500000) rotate(90.000000) translate(-229.500000, -241.500000) " cx="229.5" cy="241.5" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#FFFFFF" stroke-width="15" transform="translate(229.500000, 241.500000) rotate(90.000000) translate(-229.500000, -241.500000) " cx="229.5" cy="241.5" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#00D8FF" stroke-width="23" transform="translate(229.661197, 242.002830) rotate(30.000000) translate(-229.661197, -242.002830) " cx="229.661197" cy="242.00283" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#FFFFFF" stroke-width="15" transform="translate(229.661197, 242.002830) rotate(30.000000) translate(-229.661197, -242.002830) " cx="229.661197" cy="242.00283" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#00D8FF" stroke-width="23" transform="translate(229.661197, 242.002830) rotate(-30.000000) translate(-229.661197, -242.002830) " cx="229.661197" cy="242.00283" rx="86.5" ry="229.5"></ellipse>
+                    <ellipse id="Oval" stroke="#FFFFFF" stroke-width="15" transform="translate(229.661197, 242.002830) rotate(-30.000000) translate(-229.661197, -242.002830) " cx="229.661197" cy="242.00283" rx="86.5" ry="229.5"></ellipse>
+                    <use id="Oval-2" stroke="#FFFFFF" mask="url(#mask-4)" stroke-width="20" stroke-dasharray="10" xlink:href="#path-3"></use>
+                    <circle id="Oval-2" fill="#FFFFFF" cx="231" cy="243" r="39"></circle>
+                </g>
+            </g>
+        </g>
     </g>
 </svg>


### PR DESCRIPTION
# Summary

As discussed in #16, there was a desire for a logo for this project. The voting was pretty unanimous on the "Blueprint w/ Background" design. This PR implements a cleaned up SVG of that logo on the Home page.

<img width="904" alt="Screen Shot 2019-07-09 at 9 56 30 AM" src="https://user-images.githubusercontent.com/1957315/60893983-d9a2d280-a22f-11e9-9736-5e954f288834.png">

## Test Plan

- I made sure the new logo looks good with the loading animation.
- I updated the Home page's snapshot tests.

## Checklist

- [X] I tested this thoroughly
- [X] I added the documentation in `README.md` (if needed)