### PR TITLE
feat(DiffComment): allow for comment collapse

### DIFF
--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -1,21 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
+import { Button } from 'antd'
 import { removeAppPathPrefix, getVersionsInDiff } from '../../../utils'
 import Markdown from '../Markdown'
 
 const CommentContainer = styled.div`
   position: relative;
-`
-
-const CommentCheckbox = styled.input`
-  display: inline-block;
-  position: absolute;
-  top: 2px;
-  left: -8px;
-  cursor: pointer;
-  &:checked + div {
-    display: none;
-  }
 `
 
 const CommentContent = styled.div`
@@ -24,6 +14,16 @@ const CommentContent = styled.div`
   padding: 16px;
   border-radius: 3px;
   color: #000;
+`
+
+const CommentButton = styled(Button)`
+  height: 16px;
+  width: 16px;
+  position: absolute;
+  top: 1px;
+  left: -10px;
+  font-size: 8px;
+  cursor: 'pointer';
 `
 
 const LINE_CHANGE_TYPES = {
@@ -70,12 +70,21 @@ const getComments = ({ newPath, fromVersion, toVersion }) => {
 }
 
 const DiffComment = ({ content }) => {
+  const [displayComment, toggleComment] = useState(true)
+
   return (
     <CommentContainer>
-      <CommentCheckbox type="checkbox" />
-      <CommentContent>
-        <Markdown>{content.props.children}</Markdown>
-      </CommentContent>
+      <CommentButton
+        shape="circle"
+        type="primary"
+        onClick={() => toggleComment(!displayComment)}
+        icon={displayComment ? 'close' : 'message'}
+      />
+      {displayComment && (
+        <CommentContent>
+          <Markdown>{content.props.children}</Markdown>
+        </CommentContent>
+      )}
     </CommentContainer>
   )
 }

--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -3,7 +3,22 @@ import styled from 'styled-components'
 import { removeAppPathPrefix, getVersionsInDiff } from '../../../utils'
 import Markdown from '../Markdown'
 
-const Container = styled.div`
+const CommentContainer = styled.div`
+  position: relative;
+`
+
+const CommentCheckbox = styled.input`
+  display: inline-block;
+  position: absolute;
+  top: 2px;
+  left: -8px;
+  cursor: pointer;
+  &:checked + div {
+    display: none;
+  }
+`
+
+const CommentContent = styled.div`
   margin: 10px;
   border: 1px solid #ddd;
   padding: 16px;
@@ -56,9 +71,12 @@ const getComments = ({ newPath, fromVersion, toVersion }) => {
 
 const DiffComment = ({ content }) => {
   return (
-    <Container>
-      <Markdown>{content.props.children}</Markdown>
-    </Container>
+    <CommentContainer>
+      <CommentCheckbox type="checkbox" />
+      <CommentContent>
+        <Markdown>{content.props.children}</Markdown>
+      </CommentContent>
+    </CommentContainer>
   )
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR resolves [#39](https://github.com/react-native-community/upgrade-helper/issues/39); The feature allows for one to collapse comments--enabling better copy/pasting of code.  To implement, I used a checkbox & *css*'s sibling combinator to display / hide the comment box.

**note**: I put the checkbox inline with the comment; however, an *antd* checkbox can be put in the title bar for each diff w/ comments (allowing for a toggling of all comments like @kelset suggested in the issue)

**note2**:  You can avoid toggling the comments all together by using the `user-select` css property.  [https://caniuse.com/#search=user-select](https://caniuse.com/#search=user-select)
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
1. Clone & run locally
2. Visit `http://localhost:3000/`
3. Choose versions (to & from)
4. Navigate to comment(s) and toggle on/off

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)

![comment-collapse](https://user-images.githubusercontent.com/11083531/61505974-9e7e6d00-a9ae-11e9-9f87-649d1ab81d9a.gif)

<img width="781" alt="Screen Shot 2019-07-18 at 10 53 01 PM" src="https://user-images.githubusercontent.com/11083531/61506047-d5ed1980-a9ae-11e9-8293-16d130bd9977.png">

<img width="784" alt="Screen Shot 2019-07-18 at 10 53 55 PM" src="https://user-images.githubusercontent.com/11083531/61506071-f0bf8e00-a9ae-11e9-9d9d-dc31059accf8.png">
