### PR TITLE
Add "view file" link

### DIFF
--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -86,6 +86,25 @@ const DownloadFileButton = styled(({ visible, toVersion, newPath, ...props }) =>
   }
 `
 
+const ViewFileButton = styled(({ visible, toVersion, newPath, ...props }) =>
+  visible ? (
+    <Button
+      {...props}
+      type="link"
+      target="_blank"
+      href={getBinaryFileURL({
+        version: toVersion,
+        path: newPath
+      })}
+    >
+      View file
+    </Button>
+  ) : null
+)`
+  font-size: 12px;
+  color: #24292e;
+`
+
 const CompleteDiffButton = styled(
   ({ diffKey, isDiffCompleted, onCompleteDiff, ...props }) =>
     isDiffCompleted ? (
@@ -167,6 +186,11 @@ const DiffHeader = styled(
         <Fragment>
           <DownloadFileButton
             visible={!hasDiff}
+            toVersion={toVersion}
+            newPath={newPath}
+          />
+          <ViewFileButton
+            visible={hasDiff}
             toVersion={toVersion}
             newPath={newPath}
           />

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -177,12 +177,12 @@ const DiffHeader = styled(
       <HeaderButtonsContainer>
         <Fragment>
           <ViewFileButton
-            visible={hasDiff}
+            visible={hasDiff && type !== 'delete'}
             version={toVersion}
             path={newPath}
           />
           <DownloadFileButton
-            visible={!hasDiff}
+            visible={!hasDiff && type !== 'delete'}
             version={toVersion}
             path={newPath}
           />

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -61,19 +61,15 @@ const HeaderButtonsContainer = styled(props => <div {...props} />)`
   float: right;
 `
 
-const DownloadFileButton = styled(({ visible, toVersion, newPath, ...props }) =>
+const DownloadFileButton = styled(({ visible, version, path, ...props }) =>
   visible ? (
     <Button
       {...props}
       type="ghost"
       shape="circle"
       icon="download"
-      onClick={() =>
-        (window.location = getBinaryFileURL({
-          version: toVersion,
-          path: newPath
-        }))
-      }
+      target="_blank"
+      href={getBinaryFileURL({ version, path })}
     />
   ) : null
 )`
@@ -86,16 +82,13 @@ const DownloadFileButton = styled(({ visible, toVersion, newPath, ...props }) =>
   }
 `
 
-const ViewFileButton = styled(({ visible, toVersion, newPath, ...props }) =>
+const ViewFileButton = styled(({ visible, version, path, ...props }) =>
   visible ? (
     <Button
       {...props}
       type="link"
       target="_blank"
-      href={getBinaryFileURL({
-        version: toVersion,
-        path: newPath
-      })}
+      href={getBinaryFileURL({ version, path })}
     >
       View file
     </Button>
@@ -105,27 +98,26 @@ const ViewFileButton = styled(({ visible, toVersion, newPath, ...props }) =>
   color: #24292e;
 `
 
-const CompleteDiffButton = styled(
-  ({ diffKey, isDiffCompleted, onCompleteDiff, ...props }) =>
-    isDiffCompleted ? (
-      <Popover content="↩️">
-        <Button
-          {...props}
-          type="ghost"
-          shape="circle"
-          icon="check"
-          onClick={() => onCompleteDiff(diffKey)}
-        />
-      </Popover>
-    ) : (
+const CompleteDiffButton = styled(({ visible, onClick, ...props }) =>
+  visible ? (
+    <Popover content="↩️">
       <Button
         {...props}
         type="ghost"
         shape="circle"
         icon="check"
-        onClick={() => onCompleteDiff(diffKey)}
+        onClick={onClick}
       />
-    )
+    </Popover>
+  ) : (
+    <Button
+      {...props}
+      type="ghost"
+      shape="circle"
+      icon="check"
+      onClick={onClick}
+    />
+  )
 )`
   font-size: 13px;
   line-height: 0;
@@ -184,20 +176,19 @@ const DiffHeader = styled(
       <BinaryBadge visible={!hasDiff} />
       <HeaderButtonsContainer>
         <Fragment>
-          <DownloadFileButton
-            visible={!hasDiff}
-            toVersion={toVersion}
-            newPath={newPath}
-          />
           <ViewFileButton
             visible={hasDiff}
-            toVersion={toVersion}
-            newPath={newPath}
+            version={toVersion}
+            path={newPath}
+          />
+          <DownloadFileButton
+            visible={!hasDiff}
+            version={toVersion}
+            path={newPath}
           />
           <CompleteDiffButton
-            diffKey={diffKey}
-            isDiffCompleted={isDiffCompleted}
-            onCompleteDiff={onCompleteDiff}
+            visible={isDiffCompleted}
+            onClick={() => onCompleteDiff(diffKey)}
           />
         </Fragment>
       </HeaderButtonsContainer>


### PR DESCRIPTION
# Summary

This PR adds a "View file" link to each file diff header when there is a diff available.

This feature is useful for some configuration files which do not need be manually merged, but could rather just be overwritten.

Another contending solution would be to always display the "Download"-button.

But, as of now, it works like this:

- If the file has a diff, the "View file" link is shown
- If the file does not have a diff the "Download" button is shown instead (i.e. for non text-files)

I think this is useful, because it shows clearer intent.

Closes #79 

## Test Plan

Screenshot:
![image](https://user-images.githubusercontent.com/8259221/62213419-272fdc80-b3a3-11e9-933d-5537ccd5ae23.png)

I copied the `DownloadFileButton` component, and changed it accordingly.

## Checklist

- [X] I tested this thoroughly
- [X] I added the documentation in `README.md` (if needed)