### PR TITLE
Only run `deploy` on branches on the original repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ workflows:
             branches:
               only:
                 - master
+              # Forked pull requests have `CIRCLE_BRANCH` set to pull/XXX
+              ignore: /pull\/[0-9]+/
 
       - deploy:
           requires:


### PR DESCRIPTION
This PR fixes #47, it disallow the `deploy` job to be run on forks, after this is merged we can enable the setting on CircleCI to run jobs on forks.