### PR TITLE
Change the color of loading skeleton

### DIFF
--- a/src/components/common/Diff/DiffLoading.js
+++ b/src/components/common/Diff/DiffLoading.js
@@ -3,12 +3,12 @@ import styled from 'styled-components'
 import ContentLoader from 'react-content-loader'
 
 const TitleLoader = () => (
-  <ContentLoader speed={1} primaryColor="#b3b3b3" secondaryColor="#e6e6e6">
-    <rect rx="3" ry="3" width="100" height="7" />{' '}
+  <ContentLoader speed={1} primaryColor="#eee" secondaryColor="#e6e6e6">
+    <rect rx="1" ry="1" width="100" height="3" />{' '}
   </ContentLoader>
 )
 const DiffLoader = () => (
-  <ContentLoader speed={1} primaryColor="#b3b3b3" secondaryColor="#e6e6e6">
+  <ContentLoader speed={1} primaryColor="#eee" secondaryColor="#e6e6e6">
     <rect x="0" y="7" rx="4" ry="4" width="90%" height="13" />{' '}
     <rect x="0" y="30" rx="4" ry="4" width="80%" height="13" />{' '}
     <rect x="0" y="53" rx="3" ry="3" width="70%" height="10" />
@@ -19,30 +19,22 @@ const DiffLoader = () => (
 )
 
 const SkeletonContainer = styled.div`
-  position: relative;
   margin-top: 16px;
-  background-color: 'white';
   border: 1px solid #e8e8e8;
   border-radius: 3px;
-  max-height: '800px';
-  overflow: hidden;
 `
 
 const Header = styled.div`
   color: #24292e;
-  line-height: 32px;
   background-color: #fafbfc;
-  border: 1px solid #e8e8e8;
-  padding: 10px 5px;
+  padding: 14px 10px;
   height: 40px;
 `
 
 const DiffDisplay = styled.div`
-  border-radius: 3px;
   padding: 5px 10px;
   height: 400px;
   column-count: 2;
-  align-items: center;
 `
 export default class UsefulContentNoData extends Component {
   render() {


### PR DESCRIPTION
# Summary

This PR improves the work done on #85 a little bit but lightning the color of the skeleton to match the current colors in the app and "be easier in the eyes".

It also removes a few unused CSS properties.

Have some gifs: you can check [before here](https://user-images.githubusercontent.com/6207220/63035326-3b073280-bebb-11e9-9c79-4f9a921137fc.gif) and [after here](https://user-images.githubusercontent.com/6207220/63035338-40647d00-bebb-11e9-850d-53601026a873.gif) or you can see it on this _very small_ table:

| Before        | After           |
| ------------- |:-------------:|
| ![before](https://user-images.githubusercontent.com/6207220/63035326-3b073280-bebb-11e9-9c79-4f9a921137fc.gif)      | ![after](https://user-images.githubusercontent.com/6207220/63035338-40647d00-bebb-11e9-850d-53601026a873.gif) |


## Test Plan

Open the demo generated by Netlify on the bottom of this PR and check it out.

## Checklist

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
