### PR TITLE
Add Decoration to DiffView

### DIFF
--- a/src/__tests__/__snapshots__/App.spec.js.snap
+++ b/src/__tests__/__snapshots__/App.spec.js.snap
@@ -3,20 +3,20 @@
 exports[`renders without crashing 1`] = `
 <div>
   <div
-    class="sc-jWBwVP eMzqrb"
+    class="sc-cMljjf kjukSP"
   >
     <div
-      class="ant-card sc-brqgnP jqshtE ant-card-bordered"
+      class="ant-card sc-jAaTju jExkfr ant-card-bordered"
     >
       <div
         class="ant-card-body"
       >
         <div
-          class="sc-cMljjf bqDeCs"
+          class="sc-jDwBTQ iPrvAS"
         >
           <img
             alt="React Native upgrade helper logo"
-            class="sc-jAaTju iQnFlP"
+            class="sc-gPEVay isecjX"
             src="logo.svg"
             title="React Native upgrade helper logo"
           />
@@ -24,13 +24,13 @@ exports[`renders without crashing 1`] = `
             href="https://react-native-community.github.io/upgrade-helper"
           >
             <h1
-              class="sc-jDwBTQ kdxkQr"
+              class="sc-iRbamj fwveLy"
             >
               React Native upgrade helper
             </h1>
           </a>
           <div
-            class="sc-gPEVay bKLGYK"
+            class="sc-jlyJG dRjxEc"
           >
             <div>
               ReactGitHubBtn - 

--- a/src/__tests__/components/__snapshots__/Home.spec.js.snap
+++ b/src/__tests__/components/__snapshots__/Home.spec.js.snap
@@ -3,20 +3,20 @@
 exports[`renders without crashing 1`] = `
 <div>
   <div
-    class="sc-jWBwVP eMzqrb"
+    class="sc-cMljjf kjukSP"
   >
     <div
-      class="ant-card sc-brqgnP jqshtE ant-card-bordered"
+      class="ant-card sc-jAaTju jExkfr ant-card-bordered"
     >
       <div
         class="ant-card-body"
       >
         <div
-          class="sc-cMljjf bqDeCs"
+          class="sc-jDwBTQ iPrvAS"
         >
           <img
             alt="React Native upgrade helper logo"
-            class="sc-jAaTju iQnFlP"
+            class="sc-gPEVay isecjX"
             src="logo.svg"
             title="React Native upgrade helper logo"
           />
@@ -24,13 +24,13 @@ exports[`renders without crashing 1`] = `
             href="https://react-native-community.github.io/upgrade-helper"
           >
             <h1
-              class="sc-jDwBTQ kdxkQr"
+              class="sc-iRbamj fwveLy"
             >
               React Native upgrade helper
             </h1>
           </a>
           <div
-            class="sc-gPEVay bKLGYK"
+            class="sc-jlyJG dRjxEc"
           >
             <div>
               ReactGitHubBtn - 

--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -1,6 +1,12 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { Diff as RDiff, Hunk, markEdits, tokenize } from 'react-diff-view'
+import {
+  Diff as RDiff,
+  Hunk,
+  markEdits,
+  tokenize,
+  Decoration as DiffDecoration
+} from 'react-diff-view'
 import DiffHeader from './DiffHeader'
 import { getComments } from './DiffComment'
 
@@ -9,6 +15,17 @@ const Container = styled.div`
   border-radius: 3px;
   margin-bottom: 16px;
   margin-top: 16px;
+`
+
+const More = styled.div`
+  background-color: #f1f8ff;
+  margin-left: 30px;
+  padding-left: 4px;
+  color: '#1b1f23b3';
+`
+
+const Decoration = styled(DiffDecoration)`
+  background-color: #dbedff;
 `
 
 const DiffView = styled(RDiff)`
@@ -122,14 +139,17 @@ const Diff = ({
 
             const tokens = tokenize(hunks, options)
 
-            return hunks.map(hunk => (
+            return hunks.map(hunk => [
+              <Decoration key={'decoration-' + hunk.content}>
+                <More>{hunk.content}</More>
+              </Decoration>,
               <Hunk
                 key={hunk.content}
                 hunk={hunk}
                 tokens={tokens}
                 gutterEvents={{ onClick: onToggleChangeSelection }}
               />
-            ))
+            ])
           }}
         </DiffView>
       )}


### PR DESCRIPTION
# Summary

This fixes #101, 
Without the decoration in hunk might lead to some misunderstanding.
In this PR decoration is added to make it more clear to the user.

## Test Plan

1. Run the PR locally
2. Open http://localhost:3000/?from=0.60.6&to=0.61.2
3. Check .gitignore

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)

<img width="1204" alt="螢幕快照 2019-10-12 上午10 58 32" src="https://user-images.githubusercontent.com/7204070/66693775-6356b600-ecdf-11e9-9442-8566d213a6c2.png">
