### PR TITLE
feat: move AppNameWarning to DiffViewer

### DIFF
--- a/src/components/common/AppNameWarning.js
+++ b/src/components/common/AppNameWarning.js
@@ -1,17 +1,22 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Alert } from 'antd'
+import Markdown from './Markdown'
 
 const Container = styled.div({
-  width: '100%'
+  width: '100%',
+  marginTop: '16px'
 })
 
 export const AppNameWarning = () => (
   <Container>
     <Alert
-      message="Don't forget: `RnDiffApp` is a placeholder. When upgrading, all
-          instances of `RnDiffApp` should be `YourProjectName`, all `rndiffapp`
-          should be `yourprojectname` etc."
+      message={
+        <Markdown>
+          Keep in mind that `RnDiffApp` and `rndiffapp` are placeholders. When
+          upgrading, you should replace them with your actual project's name.
+        </Markdown>
+      }
       type="info"
       closable
     />

--- a/src/components/common/AppNameWarning.js
+++ b/src/components/common/AppNameWarning.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Alert } from 'antd'
+
+const Container = styled.div({
+  width: '100%'
+})
+
+export const AppNameWarning = () => (
+  <Container>
+    <Alert
+      message="Don't forget: `RnDiffApp` is a placeholder. When upgrading, all
+          instances of `RnDiffApp` should be `YourProjectName`, all `rndiffapp`
+          should be `yourprojectname` etc."
+      type="info"
+      closable
+    />
+  </Container>
+)

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -10,6 +10,7 @@ import UsefulContentSection from './UsefulContentSection'
 import ViewStyleOptions from './Diff/DiffViewStyleOptions'
 
 import CompletedFilesCounter from './CompletedFilesCounter'
+import { AppNameWarning } from './AppNameWarning'
 
 const Container = styled.div`
   width: 90%;
@@ -116,6 +117,9 @@ const DiffViewer = ({
         fromVersion={fromVersion}
         toVersion={toVersion}
       />
+
+      <AppNameWarning />
+
       <ViewStyleOptions
         handleViewStyleChange={handleViewStyleChange}
         diffViewStyle={diffViewStyle}

--- a/src/components/common/Markdown.js
+++ b/src/components/common/Markdown.js
@@ -19,7 +19,7 @@ const InlineCode = styled.em`
   padding: 0.2em 0.4em;
 `
 
-export default ({ forceBlock, options = {}, ...props }) => (
+export default ({ forceBlock = false, options = {}, ...props }) => (
   <Markdown
     {...props}
     options={{

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { Alert, Card } from 'antd'
+import { Card } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
@@ -28,13 +28,6 @@ const TitleContainer = styled.div`
   align-items: center;
 `
 
-const Subtitle = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  marginTop: 50
-})
-
 const LogoImg = styled.img`
   width: 100px;
   margin-bottom: 15px;
@@ -59,7 +52,6 @@ const Home = () => {
   const [fromVersion, setFromVersion] = useState('')
   const [toVersion, setToVersion] = useState('')
   const [showDiff, setShowDiff] = useState(false)
-  const [showAppNameWarning, setAppNameWarning] = useState(false)
   const [settings, setSettings] = useState({
     [`${SHOW_LATEST_RCS}`]: false
   })
@@ -78,7 +70,6 @@ const Home = () => {
 
     setFromVersion(fromVersion)
     setToVersion(toVersion)
-    setAppNameWarning(true)
     setShowDiff(true)
   }
 
@@ -121,19 +112,6 @@ const Home = () => {
           showDiff={handleShowDiff}
           showReleaseCandidates={settings[SHOW_LATEST_RCS]}
         />
-
-        {showAppNameWarning ? (
-          <Subtitle>
-            <Alert
-              message="Don't forget: `RnDiffApp` is a placeholder. When upgrading, all
-          instances of `RnDiffApp` should be `YourProjectName`, all `rndiffapp`
-          should be `yourprojectname` etc."
-              type="warning"
-              closable
-              onClose={() => setAppNameWarning(false)}
-            />
-          </Subtitle>
-        ) : null}
       </Container>
 
       <DiffViewer


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR is part of #113 

- Moved AppNameWarning to be displayed after the `UsefulContent` Section of DiffViewer (will only be displayed once diff is rendered)
- fixed the style to match the `UsefulContent` width
- changed Alert style from `warning` to `info`

NOTE: `semver` 7.x threw an error when I was working on this locally, so I had to change `semver` back to `6.3.0`
I'll add the comment about being able to change the AppName once #111 is merged :)

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

![Kapture 2019-12-31 at 14 07 20](https://user-images.githubusercontent.com/6936373/71610786-4ee7d280-2bd7-11ea-99fb-865066f72069.gif)


## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
