### PR TITLE
Change the close button on `UsefulContentSection` to match the app name warning

### DIFF
--- a/src/__tests__/components/common/__snapshots__/UsefulContentSection.spec.js.snap
+++ b/src/__tests__/components/common/__snapshots__/UsefulContentSection.spec.js.snap
@@ -19,7 +19,7 @@ exports[`renders without crashing 1`] = `
          Useful content for upgrading
       </h2>
       <button
-        class="ant-btn sc-EHOje xNCZY ant-btn-ghost ant-btn-circle ant-btn-icon-only"
+        class="ant-btn sc-EHOje kMAZtT ant-btn-link ant-btn-icon-only"
         type="button"
       >
         <i

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -29,24 +29,18 @@ const Icon = styled(props => (
 `
 
 const CloseButton = styled(({ toggleVisibility, ...props }) => (
-  <Button
-    {...props}
-    type="ghost"
-    shape="circle"
-    icon="close"
-    onClick={toggleVisibility}
-  />
+  <Button {...props} type="link" icon="close" onClick={toggleVisibility} />
 ))`
   float: right;
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 11px;
+  right: 12px;
   font-size: 12px;
   border-width: 0px;
   width: 20px;
   height: 20px;
   margin-right: 8px;
-  &,
+  color: rgba(0, 0, 0, 0.45);
   &:hover,
   &:focus {
     color: #24292e;


### PR DESCRIPTION
# Summary

This is a very small PR to fix a small issue with the close button on the `UsefulContentSection` and make it match with the App name warning.

| Before | After |
|:------:|:-----:|
|![image](https://user-images.githubusercontent.com/6207220/71806879-44f82080-306a-11ea-9302-01f78b5b1a71.png)|![image](https://user-images.githubusercontent.com/6207220/71806820-22660780-306a-11ea-82e8-a890c53ea3ad.png)|





