### PR TITLE
fix: remove app prefix when `appName` is set

### DIFF
--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -89,7 +89,8 @@ const Diff = ({
   onToggleChangeSelection,
   areAllCollapsed,
   setAllCollapsed,
-  diffViewStyle
+  diffViewStyle,
+  appName
 }) => {
   const [isDiffCollapsed, setIsDiffCollapsed] = useState(
     isDiffCollapsedByDefault({ type, hunks })
@@ -121,6 +122,7 @@ const Diff = ({
         }}
         isDiffCompleted={isDiffCompleted}
         onCompleteDiff={onCompleteDiff}
+        appName={appName}
       />
 
       {!isDiffCollapsed && (
@@ -128,7 +130,7 @@ const Diff = ({
           viewType={diffViewStyle}
           diffType={type}
           hunks={hunks}
-          widgets={getComments({ newPath, fromVersion, toVersion })}
+          widgets={getComments({ newPath, fromVersion, toVersion, appName })}
           optimizeSelection={true}
           selectedChanges={selectedChanges}
         >

--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -35,8 +35,8 @@ const LINE_CHANGE_TYPES = {
 const getLineNumberWithType = ({ lineChangeType, lineNumber }) =>
   `${LINE_CHANGE_TYPES[lineChangeType.toUpperCase()]}${lineNumber}`
 
-const getComments = ({ newPath, fromVersion, toVersion }) => {
-  const newPathSanitized = removeAppPathPrefix(newPath)
+const getComments = ({ newPath, fromVersion, toVersion, appName }) => {
+  const newPathSanitized = removeAppPathPrefix(newPath, appName)
 
   const versionsInDiff = getVersionsInDiff({ fromVersion, toVersion }).filter(
     ({ comments }) =>

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -9,9 +9,9 @@ const FileRenameArrow = styled(props => <Icon {...props} type="right" />)`
   color: #f78206;
 `
 
-const FileName = ({ oldPath, newPath, type }) => {
-  const oldPathSanitized = removeAppPathPrefix(oldPath)
-  const newPathSanitized = removeAppPathPrefix(newPath)
+const FileName = ({ oldPath, newPath, type, appName }) => {
+  const oldPathSanitized = removeAppPathPrefix(oldPath, appName)
+  const newPathSanitized = removeAppPathPrefix(newPath, appName)
 
   if (type === 'delete') {
     return <span>{oldPathSanitized}</span>
@@ -163,6 +163,7 @@ const DiffHeader = styled(
     setIsDiffCollapsed,
     isDiffCompleted,
     onCompleteDiff,
+    appName,
     ...props
   }) => (
     <div {...props}>
@@ -171,7 +172,12 @@ const DiffHeader = styled(
         isDiffCollapsed={isDiffCollapsed}
         onClick={({ altKey }) => setIsDiffCollapsed(!isDiffCollapsed, altKey)}
       />
-      <FileName oldPath={oldPath} newPath={newPath} type={type} />{' '}
+      <FileName
+        oldPath={oldPath}
+        newPath={newPath}
+        type={type}
+        appName={appName}
+      />{' '}
       <FileStatus type={type} />
       <BinaryBadge visible={!hasDiff} />
       <HeaderButtonsContainer>

--- a/src/components/common/Diff/DiffSection.js
+++ b/src/components/common/Diff/DiffSection.js
@@ -17,7 +17,8 @@ const DiffSection = ({
   handleCompleteDiff,
   selectedChanges,
   onToggleChangeSelection,
-  diffViewStyle
+  diffViewStyle,
+  appName
 }) => {
   const [areAllCollapsed, setAllCollapsed] = useState(undefined)
 
@@ -50,6 +51,7 @@ const DiffSection = ({
             onToggleChangeSelection={onToggleChangeSelection}
             areAllCollapsed={areAllCollapsed}
             setAllCollapsed={setAllCollapsed}
+            appName={appName}
           />
         )
       })}

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -64,9 +64,7 @@ const DiffViewer = ({
 
   const replaceAppName = useCallback(
     text => {
-      console.log(appName)
       if (!appName) return text
-      console.log('blank', appName)
       return text
         .replace(/RnDiffApp/g, appName)
         .replace(/rndiffapp/g, appName.toLowerCase())

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -64,7 +64,9 @@ const DiffViewer = ({
 
   const replaceAppName = useCallback(
     text => {
+      console.log(appName)
       if (!appName) return text
+      console.log('blank', appName)
       return text
         .replace(/RnDiffApp/g, appName)
         .replace(/rndiffapp/g, appName.toLowerCase())
@@ -145,11 +147,17 @@ const DiffViewer = ({
         {...diffSectionProps}
         isDoneSection={false}
         diffViewStyle={diffViewStyle}
+        appName={appName}
       />
 
       {renderUpgradeDoneMessage({ diff, completedDiffs })}
 
-      <DiffSection {...diffSectionProps} isDoneSection={true} title="Done" />
+      <DiffSection
+        {...diffSectionProps}
+        isDoneSection={true}
+        title="Done"
+        appName={appName}
+      />
 
       <CompletedFilesCounter
         completed={completedDiffs.length}

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,8 @@ export const getDiffPatchURL = ({ fromVersion, toVersion }) =>
 export const getBinaryFileURL = ({ version, path }) =>
   `https://github.com/${RN_DIFF_REPO}/raw/release/${version}/${path}`
 
-export const removeAppPathPrefix = path => path.replace(/RnDiffApp\//, '')
+export const removeAppPathPrefix = (path, appName) =>
+  path.replace(new RegExp(`${appName || 'RnDiffApp'}/`), '')
 
 export const getVersionsInDiff = ({ fromVersion, toVersion }) => {
   const cleanedToVersion = semver.valid(semver.coerce(toVersion))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I've noticed that `removeAppPathPrefix` will not work when appName is set.
Modified the DiffSections so that AppPathPrefix will be hidden even when appName is set.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly

