### PR TITLE
Add button to copy path to clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "16.13.0",
     "react-app-rewired": "2.1.5",
     "react-content-loader": "5.0.2",
+    "react-copy-to-clipboard": "^5.0.2",
     "react-diff-view": "2.4.1",
     "react-dom": "16.13.0",
     "react-dom-confetti": "0.1.3",

--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from '@emotion/styled'
 import {
   Diff as RDiff,
@@ -95,6 +95,19 @@ const Diff = ({
   const [isDiffCollapsed, setIsDiffCollapsed] = useState(
     isDiffCollapsedByDefault({ type, hunks })
   )
+  const [isPathCopiedToClipboard, setIsPathCopiedToClipboard] = useState(false)
+
+  const handleCopyPathToClipboard = () => {
+    setIsPathCopiedToClipboard(true)
+  }
+
+  useEffect(() => {
+    if (isPathCopiedToClipboard === true) {
+      setTimeout(() => {
+        setIsPathCopiedToClipboard(false)
+      }, 5000)
+    }
+  }, [isPathCopiedToClipboard])
 
   if (areAllCollapsed !== undefined && areAllCollapsed !== isDiffCollapsed) {
     setIsDiffCollapsed(areAllCollapsed)
@@ -121,6 +134,8 @@ const Diff = ({
           setIsDiffCollapsed(collapse)
         }}
         isDiffCompleted={isDiffCompleted}
+        onCopyPathToClipboard={handleCopyPathToClipboard}
+        isPathCopiedToClipboard={isPathCopiedToClipboard}
         onCompleteDiff={onCompleteDiff}
         appName={appName}
       />

--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import {
   Diff as RDiff,
@@ -95,19 +95,25 @@ const Diff = ({
   const [isDiffCollapsed, setIsDiffCollapsed] = useState(
     isDiffCollapsedByDefault({ type, hunks })
   )
-  const [isPathCopiedToClipboard, setIsPathCopiedToClipboard] = useState(false)
+  const copyPathPopoverContentOpts = {
+    default: 'Copy path to clipboard',
+    copied: 'Copied!'
+  }
+  const [copyPathPopoverContent, setCopyPathPopoverContent] = useState(
+    copyPathPopoverContentOpts.default
+  )
 
   const handleCopyPathToClipboard = () => {
-    setIsPathCopiedToClipboard(true)
+    setCopyPathPopoverContent(copyPathPopoverContentOpts.copied)
   }
 
-  useEffect(() => {
-    if (isPathCopiedToClipboard === true) {
-      setTimeout(() => {
-        setIsPathCopiedToClipboard(false)
-      }, 5000)
+  const handleResetCopyPathPopoverContent = () => {
+    console.log('outside', copyPathPopoverContent)
+    if (copyPathPopoverContent === copyPathPopoverContentOpts.copied) {
+      console.log('inside', copyPathPopoverContent)
+      setCopyPathPopoverContent(copyPathPopoverContentOpts.default)
     }
-  }, [isPathCopiedToClipboard])
+  }
 
   if (areAllCollapsed !== undefined && areAllCollapsed !== isDiffCollapsed) {
     setIsDiffCollapsed(areAllCollapsed)
@@ -135,7 +141,8 @@ const Diff = ({
         }}
         isDiffCompleted={isDiffCompleted}
         onCopyPathToClipboard={handleCopyPathToClipboard}
-        isPathCopiedToClipboard={isPathCopiedToClipboard}
+        copyPathPopoverContent={copyPathPopoverContent}
+        resetCopyPathPopoverContent={handleResetCopyPathPopoverContent}
         onCompleteDiff={onCompleteDiff}
         appName={appName}
       />

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -1,13 +1,15 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { Tag, Button, Popover } from 'antd'
 import {
   CheckOutlined,
   DownloadOutlined,
   DownOutlined,
-  RightOutlined
+  RightOutlined,
+  CopyOutlined
 } from '@ant-design/icons'
 import { removeAppPathPrefix, getBinaryFileURL } from '../../../utils'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
 
 const Wrapper = styled.div`
   display: flex;
@@ -140,7 +142,33 @@ const CompleteDiffButton = styled(({ visible, onClick, ...props }) =>
   }
 `
 
+const CopyPathToClipboardButton = styled(
+  ({ path, appName, onCopy, isPathCopiedToClipboard, ...props }) => (
+    <CopyToClipboard text={removeAppPathPrefix(path, appName)} onCopy={onCopy}>
+      <Popover
+        content={isPathCopiedToClipboard ? 'Copied!' : 'Copy path to clipboard'}
+        trigger="hover"
+      >
+        <Button
+          {...props}
+          type="ghost"
+          shape="circle"
+          icon={<CopyOutlined />}
+        />
+      </Popover>
+    </CopyToClipboard>
+  )
+)`
+  font-size: 13px;
+  line-height: 0;
+  border-width: 0px;
+  width: 20px;
+  height: 20px;
+  margin: 5px 0;
+`
+
 const CollapseClickableArea = styled.div`
+  display: inline-block;
   &:hover {
     cursor: pointer;
   }
@@ -176,26 +204,36 @@ const DiffHeader = styled(
     setIsDiffCollapsed,
     isDiffCompleted,
     onCompleteDiff,
+    onCopyPathToClipboard,
+    isPathCopiedToClipboard,
     appName,
     ...props
   }) => (
     <Wrapper {...props}>
-      <CollapseClickableArea
-        onClick={({ altKey }) => setIsDiffCollapsed(!isDiffCollapsed, altKey)}
-      >
-        <CollapseDiffButton
-          visible={hasDiff}
-          isDiffCollapsed={isDiffCollapsed}
-        />
-        <FileName
-          oldPath={oldPath}
-          newPath={newPath}
-          type={type}
+      <div>
+        <CollapseClickableArea
+          onClick={({ altKey }) => setIsDiffCollapsed(!isDiffCollapsed, altKey)}
+        >
+          <CollapseDiffButton
+            visible={hasDiff}
+            isDiffCollapsed={isDiffCollapsed}
+          />
+          <FileName
+            oldPath={oldPath}
+            newPath={newPath}
+            type={type}
+            appName={appName}
+          />{' '}
+          <FileStatus type={type} />
+          <BinaryBadge visible={!hasDiff} />
+        </CollapseClickableArea>
+        <CopyPathToClipboardButton
+          path={oldPath}
           appName={appName}
-        />{' '}
-        <FileStatus type={type} />
-        <BinaryBadge visible={!hasDiff} />
-      </CollapseClickableArea>
+          onCopy={onCopyPathToClipboard}
+          isPathCopiedToClipboard={isPathCopiedToClipboard}
+        />
+      </div>
       <div>
         <Fragment>
           <ViewFileButton

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -107,13 +107,22 @@ const ViewFileButton = styled(({ visible, version, path, ...props }) =>
   color: #24292e;
 `
 
+const defaultIconButtonStyle = `
+  font-size: 13px;
+  line-height: 0;
+  border-width: 0px;
+  width: 22px;
+  height: 22px;
+  margin: 5px 0;
+  border-radius: 50%;
+`
+
 const CompleteDiffButton = styled(({ visible, onClick, ...props }) =>
   visible ? (
     <Popover content="↩️">
       <Button
         {...props}
         type="ghost"
-        shape="circle"
         icon={<CheckOutlined />}
         onClick={onClick}
       />
@@ -122,18 +131,12 @@ const CompleteDiffButton = styled(({ visible, onClick, ...props }) =>
     <Button
       {...props}
       type="ghost"
-      shape="circle"
       icon={<CheckOutlined />}
       onClick={onClick}
     />
   )
 )`
-  font-size: 13px;
-  line-height: 0;
-  border-width: 0px;
-  width: 20px;
-  height: 20px;
-  margin: 5px 8px 0;
+  ${defaultIconButtonStyle}
   &,
   &:hover,
   &:focus {
@@ -149,22 +152,12 @@ const CopyPathToClipboardButton = styled(
         content={isPathCopiedToClipboard ? 'Copied!' : 'Copy path to clipboard'}
         trigger="hover"
       >
-        <Button
-          {...props}
-          type="ghost"
-          shape="circle"
-          icon={<CopyOutlined />}
-        />
+        <Button {...props} type="ghost" icon={<CopyOutlined />} />
       </Popover>
     </CopyToClipboard>
   )
 )`
-  font-size: 13px;
-  line-height: 0;
-  border-width: 0px;
-  width: 20px;
-  height: 20px;
-  margin: 5px 0;
+  ${defaultIconButtonStyle}
 `
 
 const CollapseClickableArea = styled.div`

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -154,14 +154,8 @@ const CopyPathToClipboardButton = styled(
     resetCopyPathPopoverContent,
     ...props
   }) => (
-    <CopyToClipboard
-      text={removeAppPathPrefix(path, appName)}
-      onCopy={onCopy}
-    >
-      <Popover
-        content={copyPathPopoverContent}
-        trigger="hover"
-      >
+    <CopyToClipboard text={removeAppPathPrefix(path, appName)} onCopy={onCopy}>
+      <Popover content={copyPathPopoverContent} trigger="hover">
         <Button
           {...props}
           type="ghost"

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -154,8 +154,14 @@ const CopyPathToClipboardButton = styled(
     resetCopyPathPopoverContent,
     ...props
   }) => (
-    <CopyToClipboard text={removeAppPathPrefix(path, appName)} onCopy={onCopy}>
-      <Popover content={copyPathPopoverContent} trigger="hover">
+    <CopyToClipboard
+      text={removeAppPathPrefix(path, appName)}
+      onCopy={onCopy}
+    >
+      <Popover
+        content={copyPathPopoverContent}
+        trigger="hover"
+      >
         <Button
           {...props}
           type="ghost"

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment } from 'react'
 import styled from '@emotion/styled'
 import { Tag, Button, Popover } from 'antd'
 import {

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -146,13 +146,22 @@ const CompleteDiffButton = styled(({ visible, onClick, ...props }) =>
 `
 
 const CopyPathToClipboardButton = styled(
-  ({ path, appName, onCopy, isPathCopiedToClipboard, ...props }) => (
+  ({
+    path,
+    appName,
+    onCopy,
+    copyPathPopoverContent,
+    resetCopyPathPopoverContent,
+    ...props
+  }) => (
     <CopyToClipboard text={removeAppPathPrefix(path, appName)} onCopy={onCopy}>
-      <Popover
-        content={isPathCopiedToClipboard ? 'Copied!' : 'Copy path to clipboard'}
-        trigger="hover"
-      >
-        <Button {...props} type="ghost" icon={<CopyOutlined />} />
+      <Popover content={copyPathPopoverContent} trigger="hover">
+        <Button
+          {...props}
+          type="ghost"
+          icon={<CopyOutlined />}
+          onMouseOver={resetCopyPathPopoverContent}
+        />
       </Popover>
     </CopyToClipboard>
   )
@@ -198,7 +207,8 @@ const DiffHeader = styled(
     isDiffCompleted,
     onCompleteDiff,
     onCopyPathToClipboard,
-    isPathCopiedToClipboard,
+    copyPathPopoverContent,
+    resetCopyPathPopoverContent,
     appName,
     ...props
   }) => (
@@ -224,7 +234,8 @@ const DiffHeader = styled(
           path={oldPath}
           appName={appName}
           onCopy={onCopyPathToClipboard}
-          isPathCopiedToClipboard={isPathCopiedToClipboard}
+          copyPathPopoverContent={copyPathPopoverContent}
+          resetCopyPathPopoverContent={resetCopyPathPopoverContent}
         />
       </div>
       <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,6 +3543,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 copy-to-clipboard@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
@@ -9703,6 +9710,14 @@ react-content-loader@5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-5.0.2.tgz#f4d417ac2b3a913a4b5e406b8b36ff724bcfe15b"
   integrity sha512-d9+/FX640VXyO+9dBgMWaHD5IL0+tGsCAFBhYPGNziPx2abTMUBXL1+oIlenOTYlxuOWDcUcpmgjj4Ws+0xdhA==
+
+react-copy-to-clipboard@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz#d82a437e081e68dfca3761fbd57dbf2abdda1316"
+  integrity sha512-/2t5mLMMPuN5GmdXo6TebFa8IoFxZ+KTDDqYhcDm0PhkgEzSxVvIX26G20s1EB02A4h2UZgwtfymZ3lGJm0OLg==
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
 
 react-dev-utils@^10.2.0:
   version "10.2.0"


### PR DESCRIPTION
# Summary
Adding a button to copy the file path to clipboard makes it easier to search for the file (eg. Command + Shift + O in JetBrain's IDE's) and make the necessary modifications. This is similar to the feature GitHub has.

Note that I'm using the `oldPath` going out from the assumption people will want to search for the file in the old version, and then do the modification to that.

## What are the steps to reproduce?
1. Click the copy button next to the file name.
2. Paste clipboard content: you will see the file path added.
![screencast 2020-03-12 18-29-02](https://user-images.githubusercontent.com/5822748/76548700-74267600-648f-11ea-8df7-3cf282ad59c0.gif)
