### PR TITLE
Fix copy path popover content jumping

### DIFF
--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -97,7 +97,7 @@ const Diff = ({
   )
   const copyPathPopoverContentOpts = {
     default: 'Copy path to clipboard',
-    copied: 'Copied!'
+    copied: 'File path copied!'
   }
   const [copyPathPopoverContent, setCopyPathPopoverContent] = useState(
     copyPathPopoverContentOpts.default
@@ -108,9 +108,7 @@ const Diff = ({
   }
 
   const handleResetCopyPathPopoverContent = () => {
-    console.log('outside', copyPathPopoverContent)
     if (copyPathPopoverContent === copyPathPopoverContentOpts.copied) {
-      console.log('inside', copyPathPopoverContent)
       setCopyPathPopoverContent(copyPathPopoverContentOpts.default)
     }
   }

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -155,7 +155,14 @@ const CopyPathToClipboardButton = styled(
     ...props
   }) => (
     <CopyToClipboard text={removeAppPathPrefix(path, appName)} onCopy={onCopy}>
-      <Popover content={copyPathPopoverContent} trigger="hover">
+      <Popover
+        content={copyPathPopoverContent}
+        trigger="hover"
+        overlayStyle={{
+          width: '175px',
+          textAlign: 'center'
+        }}
+      >
         <Button
           {...props}
           type="ghost"


### PR DESCRIPTION
When you click the Copy path to clipboard button too quick, the `Copied!` text jumps to the left. I have fixed this by hard-coding the width of the popover.

This was the issue:
![Kapture_2020-03-13_at_14 48 53](https://user-images.githubusercontent.com/100233/76626814-2581e600-653a-11ea-9a3f-e86e9e9f581c.gif)

And this is how it looks after the change:
![2020-03-13 17 39 38](https://user-images.githubusercontent.com/5822748/76641293-a8626b00-6551-11ea-943b-a283f8ffdf5c.gif)