### PR TITLE
Fix alignment of `UsefulContentSection` close button

### DIFF
--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -45,7 +45,6 @@ const CloseButton = styled(({ toggleVisibility, ...props }) => (
   border-width: 0px;
   width: 20px;
   height: 20px;
-  margin-right: 8px;
   color: rgba(0, 0, 0, 0.45);
   &:hover,
   &:focus {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

This PR fixes a small misalignment between the close buttons:

### Before

![image](https://user-images.githubusercontent.com/6207220/76845632-785fe400-683f-11ea-8dd7-2e4e1ee023be.png)

### After

![image](https://user-images.githubusercontent.com/6207220/76845657-8281e280-683f-11ea-9f8c-6f8270fdb965.png)