### PR TITLE
Replace check icon with rollback (popover is unnecessary)

### DIFF
--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -6,7 +6,8 @@ import {
   DownloadOutlined,
   DownOutlined,
   RightOutlined,
-  CopyOutlined
+  CopyOutlined,
+  RollbackOutlined
 } from '@ant-design/icons'
 import { removeAppPathPrefix, getBinaryFileURL } from '../../../utils'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
@@ -119,14 +120,12 @@ const defaultIconButtonStyle = `
 
 const CompleteDiffButton = styled(({ visible, onClick, ...props }) =>
   visible ? (
-    <Popover content="↩️">
-      <Button
-        {...props}
-        type="ghost"
-        icon={<CheckOutlined />}
-        onClick={onClick}
-      />
-    </Popover>
+    <Button
+      {...props}
+      type="ghost"
+      icon={<RollbackOutlined />}
+      onClick={onClick}
+    />
   ) : (
     <Button
       {...props}


### PR DESCRIPTION
Turn this...
![Capto_Capture 2020-03-18_12-28-50_AM](https://user-images.githubusercontent.com/5822748/76910868-7afa2200-68af-11ea-8bbf-e231a27b0a85.png)

Into this...
![Capto_Capture 2020-03-18_12-23-42_AM](https://user-images.githubusercontent.com/5822748/76910675-f4dddb80-68ae-11ea-80a7-e5a3f5ec9f23.png)

...because I like it better that way :)

I realise this is a subjective thing, so I would not be surprised if you rejected this. There are number of reasons for it though, for one, consistency, and also the popover is unnecessary, I think.