### PR TITLE
Copy new path to clipboard if file newly added

### DIFF
--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -238,7 +238,7 @@ const DiffHeader = styled(
           <BinaryBadge visible={!hasDiff} />
         </CollapseClickableArea>
         <CopyPathToClipboardButton
-          path={oldPath}
+          path={type === 'add' ? newPath : oldPath}
           appName={appName}
           onCopy={onCopyPathToClipboard}
           copyPathPopoverContent={copyPathPopoverContent}


### PR DESCRIPTION
Complementing the copy file path to clipboard icon function, this one is to prevent copying... nothing, basically, because normally the `oldPath` would be copied, but that doesn't exist for newly added files, of course.

The reason for still copying the new path in this case is if someone wanted to create it via CLI, for example, or other means that would allow them to create a file providing the full path.
