### PR TITLE
Keep original path with `appName` of `RnDiffApp` to View or Download files

### DIFF
--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -8,7 +8,11 @@ import {
   RightOutlined,
   CopyOutlined
 } from '@ant-design/icons'
-import { removeAppPathPrefix, getBinaryFileURL } from '../../../utils'
+import {
+  removeAppPathPrefix,
+  getBinaryFileURL,
+  getOriginalPath
+} from '../../../utils'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 
 const Wrapper = styled.div`
@@ -250,12 +254,12 @@ const DiffHeader = styled(
           <ViewFileButton
             visible={hasDiff && type !== 'delete'}
             version={toVersion}
-            path={newPath}
+            path={getOriginalPath(newPath, appName)}
           />
           <DownloadFileButton
             visible={!hasDiff && type !== 'delete'}
             version={toVersion}
-            path={newPath}
+            path={getOriginalPath(newPath, appName)}
           />
           <CompleteDiffButton
             visible={isDiffCompleted}

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,6 +15,9 @@ export const getBinaryFileURL = ({ version, path }) =>
 export const removeAppPathPrefix = (path, appName) =>
   path.replace(new RegExp(`${appName || 'RnDiffApp'}/`), '')
 
+export const getOriginalPath = (path, appName) =>
+  path.replace(new RegExp(`${appName}`), 'RnDiffApp')
+
 export const getVersionsInDiff = ({ fromVersion, toVersion }) => {
   const cleanedToVersion = semver.valid(semver.coerce(toVersion))
 


### PR DESCRIPTION
If you change the App Name on top, then click on View file or the download icon, you'll get redirected to a dead link because the app name is also replaced in the path to the one the user set.

I changed it so it reverts to the default RnDiffApp only for view and download to prevent the 404 error.