### PR TITLE
Use app name replacement only in the file header and not the content

### DIFF
--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -96,7 +96,7 @@ const Diff = ({
     isDiffCollapsedByDefault({ type, hunks })
   )
   const copyPathPopoverContentOpts = {
-    default: 'Copy path to clipboard',
+    default: 'Click to copy file path',
     copied: 'File path copied!'
   }
   const [copyPathPopoverContent, setCopyPathPopoverContent] = useState(

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { Alert } from 'antd'
 import { parseDiff, withChangeSelect } from 'react-diff-view'
@@ -62,16 +62,6 @@ const DiffViewer = ({
     localStorage.setItem('viewStyle', newViewStyle)
   }
 
-  const replaceAppName = useCallback(
-    text => {
-      if (!appName) return text
-      return text
-        .replace(/RnDiffApp/g, appName)
-        .replace(/rndiffapp/g, appName.toLowerCase())
-    },
-    [appName]
-  )
-
   useEffect(() => {
     if (!showDiff) {
       return
@@ -85,7 +75,7 @@ const DiffViewer = ({
       ).text()
 
       setDiff(
-        parseDiff(replaceAppName(response)).sort(({ newPath }) =>
+        parseDiff(response).sort(({ newPath }) =>
           newPath.includes('package.json') ? -1 : 1
         )
       )
@@ -101,7 +91,7 @@ const DiffViewer = ({
     return () => {
       clearTimeout(debounce)
     }
-  }, [appName, fromVersion, replaceAppName, showDiff, toVersion])
+  }, [appName, fromVersion, showDiff, toVersion])
 
   if (!showDiff) {
     return null

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import semver from 'semver/preload'
 import versions from './releases'
 
 const RN_DIFF_REPO = 'react-native-community/rn-diff-purge'
+const DEFAULT_APP_NAME = 'RnDiffApp'
 
 export const RELEASES_URL = `https://raw.githubusercontent.com/${RN_DIFF_REPO}/master/RELEASES`
 
@@ -13,10 +14,20 @@ export const getBinaryFileURL = ({ version, path }) =>
   `https://github.com/${RN_DIFF_REPO}/raw/release/${version}/${path}`
 
 export const removeAppPathPrefix = (path, appName) =>
-  path.replace(new RegExp(`${appName || 'RnDiffApp'}/`), '')
+  path.replace(new RegExp(`${appName || DEFAULT_APP_NAME}/`), '')
 
-export const getOriginalPath = (path, appName) =>
-  path.replace(new RegExp(`${appName}`), 'RnDiffApp')
+export const getPathWithProvidedAppName = (path, appName) => {
+  if (!appName) {
+    return path
+  }
+
+  return path
+    .replace(new RegExp(DEFAULT_APP_NAME, 'g'), appName)
+    .replace(
+      new RegExp(DEFAULT_APP_NAME.toLowerCase(), 'g'),
+      appName.toLowerCase()
+    )
+}
 
 export const getVersionsInDiff = ({ fromVersion, toVersion }) => {
   const cleanedToVersion = semver.valid(semver.coerce(toVersion))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

We have noticed a good amount of bugs in the last few days because of the `replace`s we do in order to change `RnDiffApp` into the name that the user chooses in the interface.

This PR changes the approach of doing this from replacing all the diff changes to only doing so for the file header and the copy file path functionality which kills the bugs we have been experiencing with the `View File` link and download button.

## Test Plan

1. Put in a few version combinations;
1. Change the app name;
1. Check that:
	- The file header is correct;
	- The `View File` goes to the right place;
	- The copy button copies the correct path with the correct app name.

Do the same without changing the app name.