### PR TITLE
changing the anchor style

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -43,11 +43,10 @@ export const getVersionsInDiff = ({ fromVersion, toVersion }) => {
   })
 }
 
+const baseChangelogURL =
+  'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md'
 export const getChangelogURL = ({ version }) =>
-  `https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#${version.replace(
-    '.',
-    ''
-  )}`
+  `${baseChangelogURL}#v${version.replace('.', '')}0`
 
 // settings constants
 export const SHOW_LATEST_RCS = 'Show latest release candidates'


### PR DESCRIPTION
# Summary

The anchor style changed.

- `0<minor>`
https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#060
- `0<minor>0`https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#0610
- `v0<minor>0`https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0620

For now I just changed this to work for the latest release, which means it breaks the links to the other older releases. 🤷‍♂️

## Test Plan
Go to a diff from 61 to 62, and click the changelog link
