### PR TITLE
Hide gradle.bat file change from 0.61 to 0.62 & Add a few links to 0.62

### DIFF
--- a/src/components/common/Diff/DiffSection.js
+++ b/src/components/common/Diff/DiffSection.js
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import styled from '@emotion/styled'
+import semver from 'semver'
 import Diff from './Diff'
 
 const Title = styled.h1`
@@ -23,6 +24,19 @@ const DiffSection = ({
 }) => {
   const [areAllCollapsed, setAllCollapsed] = useState(undefined)
 
+  const getIsUpgradingFrom61To62 = useCallback(() => {
+    const isUpgradingFrom61 = semver.satisfies(
+      fromVersion,
+      '>= 0.61.0 <= 0.62.0'
+    )
+
+    const isUpgradingTo62 = semver.satisfies(toVersion, '>= 0.62.0 <= 0.63.0')
+
+    return isUpgradingFrom61 && isUpgradingTo62
+  }, [fromVersion, toVersion])
+
+  const isUpgradingFrom61To62 = getIsUpgradingFrom61To62()
+
   return (
     <div>
       {title && completedDiffs.length > 0 && (
@@ -35,6 +49,17 @@ const DiffSection = ({
 
         // If it's the "done" section, it shouldn't show if it's not completed
         if (isDoneSection !== isDiffCompleted) {
+          return null
+        }
+
+        // This is here because there was a change in the line-endings of the
+        // `gradlew.bat` from version 0.61 to 0.62 which showed the entire file
+        // as a big change
+        if (
+          isUpgradingFrom61To62 &&
+          diffFile.oldPath.match(/gradlew.bat/) &&
+          diffFile.newPath.match(/gradlew.bat/)
+        ) {
           return null
         }
 

--- a/src/releases/0.62.js
+++ b/src/releases/0.62.js
@@ -4,24 +4,32 @@ export default {
   usefulContent: {
     description:
       'React Native 0.62 includes built-in integration with Flipper.',
-    links: []
-  },
-  comments: [
-    {
-      fileName: '.gitignore',
-      lineNumber: 23,
-      lineChangeType: 'add',
-      content: (
-        <Fragment>
-          This line should not be here. Please ignore this. It will be removed
-          on an upcoming release. Because of this line, the files
-          `ios/RnDiffApp.xcodeproj/xcshareddata/xcschemes/RnDiffApp.xcscheme`
-          and
-          `ios/RnDiffApp.xcodeproj/xcshareddata/xcschemes/RnDiffApp-tvOS.xcscheme`
-          appear as deleted. They should not be deleted from your project.
-          Ignore these two changes as well.
-        </Fragment>
-      )
-    }
-  ]
+    links: [
+      {
+        title:
+          'Official blog post about the major changes on React Native 0.62',
+        url: 'https://reactnative.dev/blog/2020/03/26/version-0.62'
+      },
+      {
+        title:
+          '[iOS] Tutorial on upgrading Xcode-related files to React Native 0.62',
+        url:
+          'https://github.com/react-native-community/upgrade-helper/issues/191'
+      }
+    ],
+    comments: [
+      {
+        fileName: 'ios/RnDiffApp.xcodeproj/project.pbxproj',
+        lineNumber: 16,
+        lineChangeType: 'neutral',
+        content: (
+          <Fragment>
+            Click
+            [here](https://github.com/react-native-community/upgrade-helper/issues/191)
+            for an explanation and some help with upgrading this file.
+          </Fragment>
+        )
+      }
+    ]
+  }
 }

--- a/src/releases/0.62.js
+++ b/src/releases/0.62.js
@@ -16,20 +16,20 @@ export default {
         url:
           'https://github.com/react-native-community/upgrade-helper/issues/191'
       }
-    ],
-    comments: [
-      {
-        fileName: 'ios/RnDiffApp.xcodeproj/project.pbxproj',
-        lineNumber: 16,
-        lineChangeType: 'neutral',
-        content: (
-          <Fragment>
-            Click
-            [here](https://github.com/react-native-community/upgrade-helper/issues/191)
-            for an explanation and some help with upgrading this file.
-          </Fragment>
-        )
-      }
     ]
-  }
+  },
+  comments: [
+    {
+      fileName: 'ios/RnDiffApp.xcodeproj/project.pbxproj',
+      lineNumber: 19,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          Click
+          [here](https://github.com/react-native-community/upgrade-helper/issues/191)
+          for an explanation and some help with upgrading this file.
+        </Fragment>
+      )
+    }
+  ]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR hides the file change of `gradle.bat` as the changes are not really useful and adds a few links to `0.62` release.

