### PR TITLE
Add comment in `0.62` for Hermes + ProGuard

### DIFF
--- a/src/releases/0.62.js
+++ b/src/releases/0.62.js
@@ -30,6 +30,18 @@ export default {
           for an explanation and some help with upgrading this file.
         </Fragment>
       )
+    },
+    {
+      fileName: 'android/app/build.gradle',
+      lineNumber: 81,
+      lineChangeType: 'neutral',
+      content: (
+        <Fragment>
+          If you are using Hermes Engine and ProGuard, make sure to update the
+          rules in `proguard-rules.pro` to what is specified in the
+          [documentation](https://reactnative.dev/docs/hermes) for `0.62`.
+        </Fragment>
+      )
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

As per the discussion at react-native-community/upgrade-support#19, this PR adds a comment to `0.62` to include highlight a change on the ProGuard rules for users using ProGuard and Hermes.

Fixes react-native-community/upgrade-support#19.

---

Comment looks like this:

![image](https://user-images.githubusercontent.com/6207220/77919388-68afb900-729d-11ea-8d3b-84d776e4ba6d.png)

