### PR TITLE
Add Upgrade Support link to `UsefulContentSection`

### DIFF
--- a/src/components/common/UpgradeSupportAlert.js
+++ b/src/components/common/UpgradeSupportAlert.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { Tooltip } from 'antd'
+
+const UpgradeSupportAlert = styled(props => (
+  <span {...props}>
+    Check out{' '}
+    <Tooltip
+      placement="bottom"
+      title="Upgrade Support is a community-backed place to request and give help when upgrading your app"
+    >
+      <a
+        href="https://github.com/react-native-community/upgrade-support"
+        target="_blank"
+        rel="noopener noreferrer"
+        {...props}
+      >
+        Upgrade Support
+      </a>
+    </Tooltip>{' '}
+    if you are experiencing issues related to React Native during the upgrading
+    process.
+  </span>
+))`
+  padding-top: 10px;
+  a {
+    color: #045dc1;
+
+    &:hover {
+      color: #40a9ff;
+    }
+  }
+`
+
+export default UpgradeSupportAlert

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -4,6 +4,7 @@ import { CloseOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
 import { getVersionsInDiff, getChangelogURL } from '../../utils'
 import { Link } from './Markdown'
+import UpgradeSupportAlert from './UpgradeSupportAlert'
 
 const Container = styled.div`
   position: relative;
@@ -15,6 +16,8 @@ const Container = styled.div`
 `
 
 const InnerContainer = styled.div`
+  display: flex;
+  flex-direction: column;
   padding: 24px;
   color: rgba(0, 0, 0, 0.65);
   border: 1px solid #e8e8e8;
@@ -136,6 +139,8 @@ class UsefulContentSection extends Component {
               </Fragment>
             )
           })}
+
+          <UpgradeSupportAlert />
         </InnerContainer>
       </Container>
     )


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR adds a mention to the [Upgrade Support](https://github.com/react-native-community/upgrade-support) repository at the top inside of the `Useful Content Section`.

---

Looks like this:

![image](https://user-images.githubusercontent.com/6207220/77919683-c9d78c80-729d-11ea-93d6-92ce4b6046fd.png)

And also has a tooltip when hovering:

![image](https://user-images.githubusercontent.com/6207220/77919726-d956d580-729d-11ea-8342-fb4da9cf1075.png)





