### PR TITLE
Add a link to the RN 0.62 upgrade guide

### DIFF
--- a/src/releases/0.57.js
+++ b/src/releases/0.57.js
@@ -4,7 +4,7 @@ export default {
       'React Native 0.57 includes 599 commits by 73 different contributors, it has improvements to Accessibility APIs, Babel 7 stable support and more.',
     links: [
       {
-        title: 'Tutorial on upgrading to React Native 0.57',
+        title: '[External] Tutorial on upgrading to React Native 0.57',
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.57/'
       }

--- a/src/releases/0.58.js
+++ b/src/releases/0.58.js
@@ -4,7 +4,7 @@ export default {
       'React Native 0.58 is the first release of 2019, it includes work for modernizing and strengthening flow types for core components and  numerous crash fixes and resolutions for unexpected behaviors.',
     links: [
       {
-        title: 'Tutorial on upgrading to React Native 0.58',
+        title: '[External] Tutorial on upgrading to React Native 0.58',
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.58/'
       }

--- a/src/releases/0.59.js
+++ b/src/releases/0.59.js
@@ -10,7 +10,7 @@ export default {
           'https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059'
       },
       {
-        title: 'Tutorial on upgrading to React Native 0.59',
+        title: '[External] Tutorial on upgrading to React Native 0.59',
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.59/'
       }

--- a/src/releases/0.60.js
+++ b/src/releases/0.60.js
@@ -12,7 +12,7 @@ export default {
           'https://facebook.github.io/react-native/blog/2019/07/03/version-60'
       },
       {
-        title: 'Tutorial on upgrading to React Native 0.60',
+        title: '[External] Tutorial on upgrading to React Native 0.60',
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.60/'
       }

--- a/src/releases/0.61.js
+++ b/src/releases/0.61.js
@@ -9,7 +9,7 @@ export default {
           'https://facebook.github.io/react-native/blog/2019/09/18/version-0.61'
       },
       {
-        title: 'Tutorial on upgrading to React Native 0.61',
+        title: '[External] Tutorial on upgrading to React Native 0.61',
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.61/'
       }

--- a/src/releases/0.62.js
+++ b/src/releases/0.62.js
@@ -11,6 +11,11 @@ export default {
         url: 'https://reactnative.dev/blog/2020/03/26/version-0.62'
       },
       {
+        title: 'Tutorial on upgrading to React Native 0.62',
+        url:
+          'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.62/'
+      },
+      {
         title:
           '[iOS] Tutorial on upgrading Xcode-related files to React Native 0.62',
         url:

--- a/src/releases/0.62.js
+++ b/src/releases/0.62.js
@@ -11,7 +11,7 @@ export default {
         url: 'https://reactnative.dev/blog/2020/03/26/version-0.62'
       },
       {
-        title: 'Tutorial on upgrading to React Native 0.62',
+        title: '[External] Tutorial on upgrading to React Native 0.62',
         url:
           'https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.62/'
       },


### PR DESCRIPTION
# Summary

Added a link to the [React Native 0.62 upgrade guide](https://reactnative.thenativebits.com/courses/upgrading-react-native/upgrade-to-react-native-0.62/). This is in the same style as the guides for previous versions, which are also linked in the upgrade helper. It tries to explain *why* the changes are needed, rather than just having a list of changes to make.

## Test Plan

N/A

## What are the steps to reproduce?

N/A

## Checklist

- [X] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
