### PR TITLE
Improve comment UI

### DIFF
--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -69,6 +69,10 @@ const DiffView = styled(RDiff)`
     width: 0;
     background-color: transparent;
   }
+
+  td.diff-widget-content {
+    padding: 0;
+  }
 `
 
 // Diff will be collapsed by default if the file has been deleted or has more than 5 hunks

--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -1,31 +1,55 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
-import { Button } from 'antd'
-import { CloseOutlined, MessageOutlined } from '@ant-design/icons'
+import AnimateHeight from 'react-animate-height'
 import { removeAppPathPrefix, getVersionsInDiff } from '../../../utils'
 import Markdown from '../Markdown'
 
-const CommentContainer = styled.div`
+const lineColors = {
+  add: '#d6fedb',
+  delete: '#fdeff0',
+  neutral: '#ffffff'
+}
+
+const Container = styled(({ isCommentVisible, className, ...props }) => (
+  <AnimateHeight
+    duration={500}
+    delay={100}
+    height={isCommentVisible ? 'auto' : 10}
+    contentClassName={className}
+    {...props}
+  />
+))`
+  display: flex;
+  flex-direction: row;
+  background-color: ${({ lineChangeType }) => lineColors[lineChangeType]};
+  overflow: hidden;
+  cursor: pointer;
+`
+
+const Content = styled.div`
+  flex: 1;
   position: relative;
-`
-
-const CommentContent = styled.div`
-  margin: 10px;
-  border: 1px solid #e8e8e8;
   padding: 16px;
-  border-radius: 3px;
   color: #000;
+  background-color: #fffbe6;
+  user-select: none;
 `
 
-const CommentButton = styled(Button)`
-  min-width: initial;
-  width: 20px;
-  height: 20px;
-  position: absolute;
-  top: -1px;
-  left: 5px;
-  font-size: 8px;
-  cursor: 'pointer';
+const ShowButton = styled.div`
+  background-color: #ffe58f;
+  margin-left: 20px;
+  width: 10px;
+  cursor: pointer;
+  ${({ isCommentVisible }) =>
+    !isCommentVisible &&
+    `
+      transform: scaleX(10);
+    `}
+  transition: transform 0.25s ease-out;
+
+  &:hover {
+    transform: ${({ isCommentVisible }) => isCommentVisible && 'scaleX(2);'};
+  }
 `
 
 const LINE_CHANGE_TYPES = {
@@ -57,7 +81,7 @@ const getComments = ({ newPath, fromVersion, toVersion, appName }) => {
         return {
           ...versionComments,
           [getLineNumberWithType({ lineChangeType, lineNumber })]: (
-            <DiffComment content={content} />
+            <DiffComment content={content} lineChangeType={lineChangeType} />
           )
         }
       },
@@ -71,23 +95,24 @@ const getComments = ({ newPath, fromVersion, toVersion, appName }) => {
   }, {})
 }
 
-const DiffComment = ({ content }) => {
-  const [displayComment, toggleComment] = useState(true)
+const DiffComment = ({ content, lineChangeType }) => {
+  const [isCommentVisible, setIsCommentVisible] = useState(true)
 
   return (
-    <CommentContainer>
-      <CommentButton
-        shape="circle"
-        type="primary"
-        onClick={() => toggleComment(!displayComment)}
-        icon={displayComment ? <CloseOutlined /> : <MessageOutlined />}
+    <Container
+      isCommentVisible={isCommentVisible}
+      lineChangeType={lineChangeType}
+      onClick={() => setIsCommentVisible(!isCommentVisible)}
+    >
+      <ShowButton
+        isCommentVisible={isCommentVisible}
+        onClick={() => setIsCommentVisible(!isCommentVisible)}
       />
-      {displayComment && (
-        <CommentContent>
-          <Markdown>{content.props.children}</Markdown>
-        </CommentContent>
-      )}
-    </CommentContainer>
+
+      <Content isCommentVisible={isCommentVisible}>
+        <Markdown>{content.props.children}</Markdown>
+      </Content>
+    </Container>
   )
 }
 

--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -26,7 +26,7 @@ const Container = styled(({ isCommentVisible, className, ...props }) => (
   cursor: pointer;
 `
 
-const Content = styled.div`
+const ContentContainer = styled.div`
   flex: 1;
   position: relative;
   padding: 16px;
@@ -50,6 +50,16 @@ const ShowButton = styled.div`
   &:hover {
     transform: ${({ isCommentVisible }) => isCommentVisible && 'scaleX(2);'};
   }
+`
+
+const Content = styled(Markdown)`
+  opacity: 1;
+  ${({ isCommentVisible }) =>
+    !isCommentVisible &&
+    `
+      opacity: 0;
+    `}
+  transition: opacity 0.25s ease-out;
 `
 
 const LINE_CHANGE_TYPES = {
@@ -109,9 +119,11 @@ const DiffComment = ({ content, lineChangeType }) => {
         onClick={() => setIsCommentVisible(!isCommentVisible)}
       />
 
-      <Content isCommentVisible={isCommentVisible}>
-        <Markdown>{content.props.children}</Markdown>
-      </Content>
+      <ContentContainer>
+        <Content isCommentVisible={isCommentVisible}>
+          {content.props.children}
+        </Content>
+      </ContentContainer>
     </Container>
   )
 }

--- a/src/components/common/Markdown.js
+++ b/src/components/common/Markdown.js
@@ -4,7 +4,12 @@ import styled from '@emotion/styled'
 
 export const Link = styled(props => (
   // eslint-disable-next-line jsx-a11y/anchor-has-content
-  <a target="_blank" {...props} rel="noopener" />
+  <a
+    target="_blank"
+    {...props}
+    rel="noopener"
+    onClick={e => e.stopPropagation()}
+  />
 ))`
   text-decoration: none;
   color: #045dc1;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR partly fixes #226, the rest of the fix will come in later :D

## Test Plan

1. Open the links from the comments;
1. Click them for collapsing;
1. Click them again for showing;
1. Make sure that you can select the comment when it's showing but not when it's hidden;

## Checklist

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)

## Known issues

Unfortunately I can't get the disable of selection working on Safari, I really tried though.

---

<details>
<summary>Before</summary>

![Before](https://user-images.githubusercontent.com/6207220/79604611-b24a3180-80ee-11ea-8db7-0c37e76e2da8.png)
</details>

<details>
<summary>After</summary>

![After](https://user-images.githubusercontent.com/6207220/79604700-dad22b80-80ee-11ea-9a85-9f89151edca9.png)
</details>

<details>
<summary>Animation</summary>

![animation](https://user-images.githubusercontent.com/6207220/79604872-2e447980-80ef-11ea-88ec-1877e3181306.gif)
</details>