### PR TITLE
Add small text to indicate the number of hidden comments

### DIFF
--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -10,6 +10,11 @@ import {
 import DiffHeader from './DiffHeader'
 import { getComments } from './DiffComment'
 
+const copyPathPopoverContentOpts = {
+  default: 'Click to copy file path',
+  copied: 'File path copied!'
+}
+
 const Container = styled.div`
   border: 1px solid #e8e8e8;
   border-radius: 3px;
@@ -99,10 +104,7 @@ const Diff = ({
   const [isDiffCollapsed, setIsDiffCollapsed] = useState(
     isDiffCollapsedByDefault({ type, hunks })
   )
-  const copyPathPopoverContentOpts = {
-    default: 'Click to copy file path',
-    copied: 'File path copied!'
-  }
+
   const [copyPathPopoverContent, setCopyPathPopoverContent] = useState(
     copyPathPopoverContentOpts.default
   )
@@ -122,6 +124,8 @@ const Diff = ({
   } else if (isDiffCompleted && isDiffCollapsed === undefined) {
     setIsDiffCollapsed(true)
   }
+
+  const diffComments = getComments({ newPath, fromVersion, toVersion, appName })
 
   return (
     <Container>
@@ -147,6 +151,7 @@ const Diff = ({
         resetCopyPathPopoverContent={handleResetCopyPathPopoverContent}
         onCompleteDiff={onCompleteDiff}
         appName={appName}
+        diffComments={diffComments}
       />
 
       {!isDiffCollapsed && (
@@ -154,7 +159,7 @@ const Diff = ({
           viewType={diffViewStyle}
           diffType={type}
           hunks={hunks}
-          widgets={getComments({ newPath, fromVersion, toVersion, appName })}
+          widgets={diffComments}
           optimizeSelection={true}
           selectedChanges={selectedChanges}
         >

--- a/src/components/common/Diff/DiffCommentReminder.js
+++ b/src/components/common/Diff/DiffCommentReminder.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { motion } from 'framer-motion'
+import { InfoCircleOutlined } from '@ant-design/icons'
+
+const DiffCommentReminder = styled(
+  ({ comments, isDiffCollapsed, uncollapseDiff, ...props }) => {
+    const numberOfComments = Object.keys(comments).length
+    const isVisible = isDiffCollapsed && numberOfComments > 0
+
+    return (
+      <motion.div
+        {...props}
+        variants={{
+          visible: { opacity: 1, cursor: 'pointer' },
+          invisible: { opacity: 0, cursor: 'initial' }
+        }}
+        animate={isVisible > 0 ? 'visible' : 'invisible'}
+        transition={{
+          duration: 0.5
+        }}
+        onClick={uncollapseDiff}
+      >
+        <InfoCircleOutlined className="icon" />
+
+        <span className="reminder">
+          {numberOfComments} hidden comment{numberOfComments > 1 && 's'}
+        </span>
+      </motion.div>
+    )
+  }
+)`
+  display: inline;
+  background-color: #fffbe6;
+  padding: 5px;
+  border-radius: 3px;
+  margin-left: 10px;
+  border: 1px solid #ffe58f;
+
+  & > .icon {
+    margin-right: 6px;
+  }
+
+  & > .reminder {
+    word-spacing: -2px;
+  }
+`
+
+export default DiffCommentReminder

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -15,6 +15,7 @@ import {
   getPathWithProvidedAppName
 } from '../../../utils'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
+import DiffCommentReminder from './DiffCommentReminder'
 
 const Wrapper = styled.div`
   display: flex;
@@ -237,6 +238,7 @@ const DiffHeader = ({
   copyPathPopoverContent,
   resetCopyPathPopoverContent,
   appName,
+  diffComments,
   ...props
 }) => {
   const sanitizedFilePaths = getFilePathsToShow({ oldPath, newPath, appName })
@@ -267,6 +269,12 @@ const DiffHeader = ({
           onCopy={onCopyPathToClipboard}
           copyPathPopoverContent={copyPathPopoverContent}
           resetCopyPathPopoverContent={resetCopyPathPopoverContent}
+        />
+
+        <DiffCommentReminder
+          comments={diffComments}
+          isDiffCollapsed={isDiffCollapsed}
+          uncollapseDiff={() => setIsDiffCollapsed(false)}
         />
       </div>
       <div>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR fixes #236 by adding a small text on the diff header to indicate the number of comments for the specific file, the text will only appear when the diff content is collapsed.

Clicking the text will show the diff content.

[You can see how it works here](https://imgur.com/a/Rz0TLCE).

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)

---

![image](https://user-images.githubusercontent.com/6207220/80724853-9ab57480-8b02-11ea-9890-ff7dd1decc3b.png)
