### PR TITLE
Add How to Use Modal

### DIFF
--- a/src/components/common/HowToUseModal.js
+++ b/src/components/common/HowToUseModal.js
@@ -1,5 +1,22 @@
 import React from 'react'
+import styled from '@emotion/styled'
 import { Modal } from 'antd'
+
+const List = styled.ol`
+  padding-left: 1em;
+`
+
+const Code = styled.code`
+  font-size: 0.8em;
+  background-color: hsla(0, 0%, 58.8%, 0.3);
+  color: #000;
+  border-radius: 6px;
+  padding: 2px 5px;
+  text-align: left;
+  white-space: pre-wrap;
+  word-spacing: normal;
+  word-break: normal;
+`
 
 const HowToUseModal = ({ visible, onClose }) => (
   <Modal
@@ -10,10 +27,51 @@ const HowToUseModal = ({ visible, onClose }) => (
     onCancel={onClose}
   >
     <p>
-      Rhoncus cras cursus sit elit non a auctor condimentum potenti, urna congue
-      luctus at interdum nullam ornare sollicitudin, tortor ad praesent molestie
-      curae ullamcorper vehicula ut.
+      The Upgrade Helper is a tool to help you out when upgrading your apps by
+      providing the full set of changes happening between any two versions.
     </p>
+    <List>
+      <li>
+        <strong>Select the versions</strong>
+        <p>
+          Select from and to which version you wish to upgrade. After selecting
+          you can click the "Show me how to upgrade" button.
+        </p>
+      </li>
+      <li>
+        <strong>Upgrade dependencies</strong>
+        <p>
+          The first file that is shown is the <Code>package.json</Code>, it's
+          good to update the dependencies that are showing in there.
+        </p>
+      </li>
+      <li>
+        <strong>Upgrade your project files</strong>
+        <p>
+          The new release may contain updates to other files that are generated
+          when you run <Code>npx react-native init</Code>, those files are
+          listed after the <Code>package.json</Code>.
+        </p>
+        <p>
+          If there aren't other changes then you only need to rebuild the
+          project to continue developing.
+        </p>
+        <p>
+          In case there are changes then you can either update them manually by
+          copying and pasting from the changes in the page or you can do it with
+          the React Native CLI upgrade command by running:
+          <br />
+          <Code>npx react-native upgrade</Code>
+        </p>
+      </li>
+    </List>
+    <a
+      href="https://reactnative.dev/docs/upgrading#upgrade-helper"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Learn More about Upgrade Helper
+    </a>
   </Modal>
 )
 

--- a/src/components/common/HowToUseModal.js
+++ b/src/components/common/HowToUseModal.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Modal } from 'antd'
+
+const HowToUseModal = ({ visible, onClose }) => (
+  <Modal title="How to Use the Upgrade Helper" visible={visible}>
+    <p>
+      Rhoncus cras cursus sit elit non a auctor condimentum potenti, urna congue
+      luctus at interdum nullam ornare sollicitudin, tortor ad praesent molestie
+      curae ullamcorper vehicula ut.
+    </p>
+  </Modal>
+)
+
+export default HowToUseModal

--- a/src/components/common/HowToUseModal.js
+++ b/src/components/common/HowToUseModal.js
@@ -2,7 +2,13 @@ import React from 'react'
 import { Modal } from 'antd'
 
 const HowToUseModal = ({ visible, onClose }) => (
-  <Modal title="How to Use the Upgrade Helper" visible={visible}>
+  <Modal
+    title="How to Use the Upgrade Helper"
+    visible={visible}
+    centered
+    footer={null}
+    onCancel={onClose}
+  >
     <p>
       Rhoncus cras cursus sit elit non a auctor condimentum potenti, urna congue
       luctus at interdum nullam ornare sollicitudin, tortor ad praesent molestie

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -127,7 +127,10 @@ const Home = () => {
               type="link"
               onClick={() => setShouldShowTutorial(true)}
             />
-            <HowToUseModal visible={shouldShowTutorial} />
+            <HowToUseModal
+              visible={shouldShowTutorial}
+              onClose={() => setShouldShowTutorial(false)}
+            />
             <Settings
               handleSettingsChange={handleSettingsChange}
               appName={appName}

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
-import { Card } from 'antd'
+import { Button, Card } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
 import Settings from '../common/Settings'
+import HowToUseModal from '../common/HowToUseModal'
 import { homepage } from '../../../package.json'
 import logo from '../../assets/logo.svg'
 import { SHOW_LATEST_RCS } from '../../utils'
@@ -22,6 +23,11 @@ const Container = styled(Card)`
   width: 90%;
   border-radius: 3px;
   border-color: #e8e8e8;
+`
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
 `
 
 const TitleContainer = styled.div`
@@ -49,10 +55,19 @@ const StarButton = styled(({ className, ...props }) => (
   margin-right: auto;
 `
 
+const HowToUseButton = styled(({ className, ...props }) => (
+  <div className={className}>
+    <Button {...props}>How to Use</Button>
+  </div>
+))`
+  margin-right: 15px;
+`
+
 const Home = () => {
   const [fromVersion, setFromVersion] = useState('')
   const [toVersion, setToVersion] = useState('')
   const [shouldShowDiff, setShouldShowDiff] = useState(false)
+  const [shouldShowTutorial, setShouldShowTutorial] = useState(false)
   const [settings, setSettings] = useState({
     [`${SHOW_LATEST_RCS}`]: false
   })
@@ -107,11 +122,18 @@ const Home = () => {
             Star
           </StarButton>
 
-          <Settings
-            handleSettingsChange={handleSettingsChange}
-            appName={appName}
-            setAppName={setAppName}
-          />
+          <Row>
+            <HowToUseButton
+              type="link"
+              onClick={() => setShouldShowTutorial(true)}
+            />
+            <HowToUseModal visible={shouldShowTutorial} />
+            <Settings
+              handleSettingsChange={handleSettingsChange}
+              appName={appName}
+              setAppName={setAppName}
+            />
+          </Row>
         </TitleContainer>
 
         <VersionSelector


### PR DESCRIPTION
Hi, this is my first time contributing to the Upgrade Helper, hope my changes will be useful
Thank you for the great tool!

# Summary

A quick prototype of #45 (How to Use Modal)

Added a _How to Use_ button on the main page. When a user clicks the button, the `HowToUseModal` component is shown displaying content based on [Upgrade Helper Docs on the React Native website](https://reactnative.dev/docs/upgrading#upgrade-helper)

Impacts: Home page

## Test Plan

1. Open PR deploy preview generated by Netlify
2. Click the _How to Use_ button in the top-right corner of the home page
3. Read the tutorial
4. Close the modal (clicking the cross icon or anywhere outside of the modal)

## Checklist

- [X] I tested this thoroughly (Safari, Chrome, Firefox)
