### PR TITLE
[Documentation] Upgrade to 0.64 useful content + hermes-engine dependency

### DIFF
--- a/src/releases/0.64.js
+++ b/src/releases/0.64.js
@@ -7,7 +7,7 @@ export default {
     links: [
       {
         title:
-          'Official blog post about the major changes on React Native 0.62',
+          'Official blog post about the major changes on React Native 0.64',
         url: 'https://reactnative.dev/blog/2021/03/12/version-0.64'
       }
     ]

--- a/src/releases/0.64.js
+++ b/src/releases/0.64.js
@@ -1,0 +1,30 @@
+import React, { Fragment } from 'react'
+
+export default {
+  usefulContent: {
+    description:
+      'React Native 0.64 includes hermes optin-in on iOS and React 17.',
+    links: [
+      {
+        title:
+          'Official blog post about the major changes on React Native 0.62',
+        url: 'https://reactnative.dev/blog/2021/03/12/version-0.64'
+      }
+    ]
+  },
+  comments: [
+    {
+      fileName: 'package.json',
+      lineNumber: 14,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          If you have the `hermes-engine` dependency you need to upgrade to
+          0.7.2 [see release
+          here](https://github.com/facebook/hermes/releases/tag/v0.7.2) if you
+          are on a previous version you might get crashes at boot on Android.
+        </Fragment>
+      )
+    }
+  ]
+}

--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -1,5 +1,5 @@
 // this line HAAAAAAAAS to go
-const versions = ['0.62', '0.61', '0.60', '0.59', '0.58', '0.57']
+const versions = ['0.64', '0.62', '0.61', '0.60', '0.59', '0.58', '0.57']
 
 export default versions.map(version => ({
   ...require(`./${version}`).default,


### PR DESCRIPTION
# Summary
We truly appreciate the work you guys did with the `upgrade-helper` tool, and would like to contribute to it 🥳 

As we upgraded from `react-native` 0.63.4  to 0.64, we were having Android crashes at boot during development/production. After triple-checking the diffs/documentation we couldn't figure out what was going, however looking on the `react-native` github issues we found other people having the same issue.

The problem is that the `hermes-engine` dependency needs to be upgraded for compatibility with `react-native` 0.64, otherwise it causes the crashes. (and unfortunately the stack traces aren't helpful at all)

Github issues regarding this:
**[[0.64] Crashes on app launch #31269](https://github.com/facebook/react-native/issues/31269)**
**[Android app bundle crashes of soloader #31350](https://github.com/facebook/react-native/issues/31350)**

## Test Plan
![image](https://user-images.githubusercontent.com/2905749/116673519-684f8900-a99b-11eb-81c6-2620555953ed.png)

## What are the steps to reproduce?
1. Run the `upgrade-helper` tool
2. Set the from `0.63.4` to `0.64`
3. See the `usefulContent` at the top and at `package.json` LOC 12 there's a comment about the `hermes-engine` dependency.

## Checklist

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)

Again, thank you for making this tool, you guys save us so much time ❤️ 