### PR TITLE
Fix hermes -> Hermes and optin-in -> opt-in

### DIFF
--- a/src/releases/0.64.js
+++ b/src/releases/0.64.js
@@ -3,7 +3,7 @@ import React, { Fragment } from 'react'
 export default {
   usefulContent: {
     description:
-      'React Native 0.64 includes hermes optin-in on iOS and React 17.',
+      'React Native 0.64 includes Hermes opt-in on iOS and React 17.',
     links: [
       {
         title:


### PR DESCRIPTION
# Summary

Fix the typo and use correct casing for Hermes (as we do for React Native, since we don't write react native here)
