### PR TITLE
Add troubleshooting guides

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,8 @@ module.exports = {
   extends: 'react-app',
   plugins: ['prettier'],
   rules: {
-    'prettier/prettier': 'error'
+    'prettier/prettier': 'error',
+    'jsx-a11y/accessible-emoji': 'off',
+    'react-hooks/exhaustive-deps': 'off'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-  extends: 'react-app',
-  plugins: ['prettier'],
-  rules: {
-    'prettier/prettier': 'error',
-    'jsx-a11y/accessible-emoji': 'off',
-    'react-hooks/exhaustive-deps': 'off'
-  }
-}

--- a/package.json
+++ b/package.json
@@ -61,5 +61,18 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app"
+    ],
+    "plugins": [
+      "prettier"
+    ],
+    "rules": {
+      "prettier/prettier": "error",
+      "jsx-a11y/accessible-emoji": "off",
+      "react-hooks/exhaustive-deps": "off"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "react-app-rewired": "^2.1.5"
   },
   "scripts": {
-    "start": "react-app-rewired start",
-    "build": "DISABLE_ESLINT_PLUGIN=true react-app-rewired build",
+    "start": "EXTEND_ESLINT=true react-app-rewired start",
+    "build": "EXTEND_ESLINT=true react-app-rewired build",
     "test": "react-app-rewired test",
     "lint": "eslint . --cache --report-unused-disable-directives",
     "eject": "react-app-rewired eject"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/core": "10.0.28",
     "@emotion/styled": "10.0.27",
     "antd": "4.0.3",
+    "date-fns": "^2.23.0",
     "framer-motion": "^2.0.0-beta.52",
     "markdown-to-jsx": "6.11.0",
     "query-string": "6.11.1",
@@ -20,7 +21,8 @@
     "react-ga": "2.7.0",
     "react-github-btn": "1.1.1",
     "react-scripts": "3.4.0",
-    "semver": "7.1.3"
+    "semver": "7.1.3",
+    "use-persisted-state": "^0.3.3"
   },
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "10.0.27",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "DISABLE_ESLINT_PLUGIN=true react-app-rewired build",
     "test": "react-app-rewired test",
     "lint": "eslint . --cache --report-unused-disable-directives",
     "eject": "react-app-rewired eject"

--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { SettingOutlined } from '@ant-design/icons'
 import { Popover, Button, Checkbox, Input } from 'antd'
 import { SHOW_LATEST_RCS } from '../../utils'
 import styled from '@emotion/styled'
@@ -7,6 +6,14 @@ import styled from '@emotion/styled'
 const InputContainer = styled.div({
   marginTop: '16px'
 })
+
+const SettingsButton = styled(Button)`
+  color: initial;
+`
+
+const SettingsIcon = styled(props => <span {...props}>⚙️</span>)`
+  font-family: initial;
+`
 
 const Settings = ({ handleSettingsChange, appName, onChangeAppName }) => {
   const [popoverVisibility, setVisibility] = useState(false)
@@ -47,7 +54,7 @@ const Settings = ({ handleSettingsChange, appName, onChangeAppName }) => {
       visible={popoverVisibility}
       onVisibleChange={handleClickChange}
     >
-      <Button icon={<SettingOutlined />} />
+      <SettingsButton icon={<SettingsIcon />} />
     </Popover>
   )
 }

--- a/src/components/common/TroubleshootingGuides.js
+++ b/src/components/common/TroubleshootingGuides.js
@@ -1,0 +1,129 @@
+import React, { useEffect, useRef } from 'react'
+import styled from '@emotion/styled'
+import { Link } from './Markdown'
+import { motion, useAnimation } from 'framer-motion'
+import { css } from '@emotion/core'
+
+const TROUBLESHOOTING_GUIDES = [
+  {
+    title: 'Xcode 12.5',
+    href: 'https://github.com/facebook/react-native/issues/31480'
+  },
+  {
+    title: 'Apple Silicon (M1)',
+    href: 'https://github.com/facebook/react-native/issues/31941'
+  }
+]
+
+const Container = styled(motion.div)`
+  ${({ willHaveAnimation }) =>
+    !willHaveAnimation &&
+    css`
+      width: 250px;
+    `}
+`
+
+const Content = styled(motion.div)`
+  ${({ willHaveAnimation }) =>
+    willHaveAnimation &&
+    css`
+      display: none;
+      opacity: 0;
+      height: 0;
+    `}
+
+  h4 {
+    border-bottom: 1px solid #e8e8e8;
+    padding-bottom: 6px;
+  }
+`
+
+const ListContainer = styled.ul`
+  padding-left: 13px;
+  margin-bottom: 0;
+  list-style: disc;
+`
+
+const TroubleshootingGuides = ({ isTooltipVisible, hasSeenTooltip }) => {
+  const hasAnimated = useRef(false)
+  const willHaveAnimation = useRef(isTooltipVisible || hasAnimated.current)
+
+  const containerAnimation = useAnimation()
+  const tooltipAnimation = useAnimation()
+  const contentAnimation = useAnimation()
+
+  useEffect(() => {
+    if (!isTooltipVisible && !hasAnimated.current) {
+      startTroubleshootingAnimation()
+
+      return
+    }
+
+    if (hasSeenTooltip) {
+      hasAnimated.current = true
+    }
+  }, [isTooltipVisible])
+
+  const startTroubleshootingAnimation = async () => {
+    if (willHaveAnimation) {
+      await Promise.all([
+        contentAnimation.start({
+          display: 'initial',
+          transition: { duration: 0 }
+        }),
+        tooltipAnimation.start({ opacity: 0, transition: { duration: 0.2 } }),
+        containerAnimation.start({
+          width: 250,
+          transition: { duration: 0.2, delay: 0.2 }
+        }),
+        tooltipAnimation.start({
+          height: 0,
+          transition: { duration: 0.2 }
+        }),
+        contentAnimation.start({
+          height: 'auto',
+          transition: { duration: 0.2 }
+        }),
+        contentAnimation.start({
+          opacity: 1,
+          transition: { duration: 0.5, delay: 0.3 }
+        })
+      ])
+      await tooltipAnimation.start({ display: 'none' })
+    }
+
+    hasAnimated.current = true
+  }
+
+  return (
+    <Container
+      willHaveAnimation={willHaveAnimation.current}
+      animate={containerAnimation}
+    >
+      <motion.div animate={tooltipAnimation}>
+        <span>
+          Check here the troubleshooting guides for issues with Xcode 12.5 or
+          Apple Silicon (M1) machine.
+        </span>
+      </motion.div>
+
+      <Content
+        willHaveAnimation={willHaveAnimation.current}
+        animate={contentAnimation}
+      >
+        <>
+          <h4>Troubleshooting guides</h4>
+          <ListContainer>
+            {TROUBLESHOOTING_GUIDES.map(({ title, href }) => (
+              <li key={href}>
+                <Link href={href}>{title}</Link>
+              </li>
+            ))}
+          </ListContainer>
+        </>
+      </Content>
+    </Container>
+  )
+}
+
+export { TroubleshootingGuides }

--- a/src/components/common/TroubleshootingGuidesButton.js
+++ b/src/components/common/TroubleshootingGuidesButton.js
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Button as AntdButton, Popover } from 'antd'
+import styled from '@emotion/styled'
+import createPersistedState from 'use-persisted-state'
+import { differenceInDays } from 'date-fns'
+import { TroubleshootingGuides } from './TroubleshootingGuides'
+
+const useTooltip = createPersistedState('troubleshootingTooltip')
+
+const Icon = styled.span`
+  font-family: initial;
+`
+
+const Button = styled(AntdButton)`
+  width: 32px;
+  padding: 0;
+  margin-right: 8px;
+  color: initial;
+`
+
+const TroubleshootingGuidesButton = () => {
+  const [showContent, setShowContent] = useState(false)
+  const [
+    shouldShowTroubleshootingGuide,
+    setShouldShowTroubleshootingGuide
+  ] = useState(false)
+  const [tooltip, setTooltip] = useTooltip({
+    hasSeen: false,
+    hasSeenAt: undefined
+  })
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false)
+  const hasHandledClick = useRef(false)
+
+  useEffect(() => {
+    if (!tooltip.hasSeen) {
+      setIsTooltipVisible(true)
+      setShowContent(true)
+
+      return
+    }
+
+    const diffInDays = differenceInDays(new Date(), new Date(tooltip.hasSeenAt))
+
+    if (diffInDays >= 2) {
+      setTooltip({ hasSeen: false, hasSeenAt: undefined })
+    }
+  }, [tooltip])
+
+  const handlePopoverVisibilityChange = visibility => {
+    if (hasHandledClick.current) {
+      return
+    }
+
+    setShowContent(false)
+  }
+
+  const handleToggleShowContent = () => {
+    hasHandledClick.current = true
+
+    if (!showContent) {
+      setShowContent(true)
+    } else if (isTooltipVisible) {
+      setIsTooltipVisible(false)
+      setShouldShowTroubleshootingGuide(!shouldShowTroubleshootingGuide)
+      setTooltip({ hasSeen: true, hasSeenAt: new Date().toISOString() })
+    } else {
+      setShowContent(!showContent)
+    }
+
+    setTimeout(() => {
+      hasHandledClick.current = false
+    }, 0)
+  }
+
+  return (
+    <Popover
+      placement="bottomRight"
+      content={
+        <TroubleshootingGuides
+          isTooltipVisible={isTooltipVisible}
+          hasSeenTooltip={tooltip.hasSeen}
+        />
+      }
+      trigger="click"
+      visible={showContent}
+      onVisibleChange={handlePopoverVisibilityChange}
+    >
+      <Button onClick={handleToggleShowContent}>
+        <Icon role="img">⚠️</Icon>
+      </Button>
+    </Popover>
+  )
+}
+
+export { TroubleshootingGuidesButton }

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
-import { Alert, Card } from 'antd'
+import { Card } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
@@ -9,7 +9,7 @@ import Settings from '../common/Settings'
 import { homepage } from '../../../package.json'
 import logo from '../../assets/logo.svg'
 import { SHOW_LATEST_RCS } from '../../utils'
-import { Link } from '../common/Markdown'
+import { TroubleshootingGuidesButton } from '../common/TroubleshootingGuidesButton'
 
 const Page = styled.div`
   display: flex;
@@ -108,34 +108,8 @@ const Home = () => {
             Star
           </StarButton>
 
-          <Alert
-            type="warning"
-            showIcon
-            message={
-              <>
-                <span>Having problems with Xcode 12.5?</span>{' '}
-                <Link href="https://github.com/facebook/react-native/issues/31480">
-                  Check here first
-                </Link>
-                <span>!</span>
-              </>
-            }
-            style={{ marginRight: 8 }}
-          />
-          <Alert
-            type="warning"
-            showIcon
-            message={
-              <>
-                <span>You have an M1 (Apple Silicon) machine?</span>{' '}
-                <Link href="https://github.com/facebook/react-native/issues/31941">
-                  Check here for help
-                </Link>
-                <span>!</span>
-              </>
-            }
-            style={{ marginRight: 8 }}
-          />
+          <TroubleshootingGuidesButton />
+
           <Settings
             handleSettingsChange={handleSettingsChange}
             appName={appName}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import './index.css';
+import './index.css'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,6 +1931,11 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
+"@use-it/event-listener@^0.1.2":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.6.tgz#5776274fec72f3f25af9ead1898e7f45bc435812"
+  integrity sha512-e6V7vbU8xpuqy4GZkTLExHffOFgxmGHo3kNWnlhzM/zcX2v+idbD/HaJ9sKdQMgTh+L7MIhdRDXGX3SdAViZzA==
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -4014,6 +4019,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+date-fns@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
 dayjs@^1.8.18:
   version "1.8.21"
@@ -11879,6 +11889,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-persisted-state@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.3.tgz#5e0f2236967cec7c34de33abc07ae6818e7c7451"
+  integrity sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==
+  dependencies:
+    "@use-it/event-listener" "^0.1.2"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR removes the current `Alert`s for the issues with Xcode 12.5 and Apple Silicon (M1) machine and adds a troubleshooting guide button.

I went a little bit over the top with the time invested on this but I think it looks great, I didn't do any handling for the versioning (yet) which should be fine for now.

The initial content (`Check here the troubleshooting guides for issues with Xcode 12.5 or Apple Silicon (M1) machine.`) will only show once to the user and, once it's closed, it will be shown only after two days.

I had to do some weird handling to know when to close or change the content because of the events that antd provides for `Popover` which are basically way too simple.

![Troubleshooting Guides](https://user-images.githubusercontent.com/6207220/128641587-310901d3-e979-4234-983d-c44b37e2e4c6.gif)

---

cc @pvinis @kelset 
