### PR TITLE
Fix file download button not working

### DIFF
--- a/src/components/common/BinaryDownload.js
+++ b/src/components/common/BinaryDownload.js
@@ -32,18 +32,29 @@ const Popover = styled(({ className, ...props }) => (
   }
 `
 
-const BinaryList = ({ binaryFiles, toVersion, appName }) =>
+const BinaryList = ({ binaryFiles, toVersion, appName, packageName }) =>
   binaryFiles.map(({ newPath }, index) => {
     return (
       <BinaryRow key={index} index={index}>
         {removeAppPathPrefix(newPath, appName)}
 
-        <DownloadFileButton visible={true} version={toVersion} path={newPath} />
+        <DownloadFileButton
+          visible={true}
+          version={toVersion}
+          path={newPath}
+          packageName={packageName}
+        />
       </BinaryRow>
     )
   })
 
-const BinaryDownload = ({ diff, fromVersion, toVersion, appName }) => {
+const BinaryDownload = ({
+  diff,
+  fromVersion,
+  toVersion,
+  appName,
+  packageName
+}) => {
   const binaryFiles = diff.filter(
     ({ hunks, type }) => hunks.length === 0 && type !== 'delete'
   )
@@ -61,6 +72,7 @@ const BinaryDownload = ({ diff, fromVersion, toVersion, appName }) => {
             binaryFiles={binaryFiles}
             toVersion={toVersion}
             appName={appName}
+            packageName={packageName}
           />
         }
         trigger="click"

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -247,6 +247,7 @@ const DiffHeader = ({
             visible={!hasDiff && type !== 'delete'}
             version={toVersion}
             path={newPath}
+            packageName={packageName}
           />
           <CompleteDiffButton
             visible={isDiffCompleted}

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -161,6 +161,7 @@ const DiffViewer = ({
               fromVersion={fromVersion}
               toVersion={toVersion}
               appName={appName}
+              packageName={packageName}
             />
 
             <ViewStyleOptions

--- a/src/components/common/DownloadFileButton.js
+++ b/src/components/common/DownloadFileButton.js
@@ -4,17 +4,20 @@ import { Button } from 'antd'
 import { DownloadOutlined } from '@ant-design/icons'
 import { getBinaryFileURL } from '../../utils'
 
-const DownloadFileButton = styled(({ visible, version, path, ...props }) =>
-  visible ? (
-    <Button
-      {...props}
-      type="ghost"
-      shape="circle"
-      icon={<DownloadOutlined />}
-      target="_blank"
-      href={getBinaryFileURL({ version, path })}
-    />
-  ) : null
+const DownloadFileButton = styled(
+  ({ visible, version, path, packageName, ...props }) => {
+    console.info(visible, version, path, packageName)
+    return visible ? (
+      <Button
+        {...props}
+        type="ghost"
+        shape="circle"
+        icon={<DownloadOutlined />}
+        target="_blank"
+        href={getBinaryFileURL({ packageName, version, path })}
+      />
+    ) : null
+  }
 )`
   color: #24292e;
   font-size: 12px;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes #285 
Fixes #287 

Pressing `DownloadFileButton` for any binary file in the diff view or binary list currently links to a broken URL (`https://github.com/undefined/[...]`), because `getBinaryFileURL()` is called without `packageName` [here](https://github.com/react-native-community/upgrade-helper/blob/93eac8f3490f02184b6763df506ce02ea0886eb9/src/components/common/DownloadFileButton.js#L15).  

I added the `packageName` parameter to the helper function call and as a prop of `DownloadFileButton`, making sure to pass it down the hierarchy as necessary.

## Test Plan

I tested the button in the diff view and binary list, it works in both places and links to the correct URL.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] ~~I added the documentation in `README.md` (if needed)~~
