### PR TITLE
Fix path not properly being shown without `RnDiffApp`

### DIFF
--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -130,7 +130,7 @@ const DiffViewer = ({
   }
 
   const diffSectionProps = {
-    diff: diff,
+    diff,
     getDiffKey: getDiffKey,
     completedDiffs: completedDiffs,
     fromVersion: fromVersion,

--- a/src/components/common/DownloadFileButton.js
+++ b/src/components/common/DownloadFileButton.js
@@ -5,9 +5,8 @@ import { DownloadOutlined } from '@ant-design/icons'
 import { getBinaryFileURL } from '../../utils'
 
 const DownloadFileButton = styled(
-  ({ visible, version, path, packageName, ...props }) => {
-    console.info(visible, version, path, packageName)
-    return visible ? (
+  ({ visible, version, path, packageName, ...props }) =>
+    visible ? (
       <Button
         {...props}
         type="ghost"
@@ -17,7 +16,6 @@ const DownloadFileButton = styled(
         href={getBinaryFileURL({ packageName, version, path })}
       />
     ) : null
-  }
 )`
   color: #24292e;
   font-size: 12px;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const DEFAULT_APP_NAME = 'RnDiffApp'
+export const DEFAULT_APP_NAMES = ['RnDiffApp', 'DiffApp']
 
 export const PACKAGE_NAMES = {
   RN: 'react-native',

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import semver from 'semver/preload'
 import {
   RN_DIFF_REPOSITORIES,
-  DEFAULT_APP_NAME,
+  DEFAULT_APP_NAMES,
   PACKAGE_NAMES,
   RN_CHANGELOG_URLS
 } from './constants'
@@ -30,7 +30,9 @@ export const getBinaryFileURL = ({ packageName, version, path }) => {
 }
 
 export const removeAppPathPrefix = (path, appName) =>
-  path.replace(new RegExp(`${appName || DEFAULT_APP_NAME}/`), '')
+  path
+    .replace(new RegExp(`${appName || DEFAULT_APP_NAMES.join('|')}/`), '')
+    .replace(/^\//, '')
 
 export const replaceWithProvidedAppName = (path, appName) => {
   if (!appName) {
@@ -38,9 +40,14 @@ export const replaceWithProvidedAppName = (path, appName) => {
   }
 
   return path
-    .replace(new RegExp(DEFAULT_APP_NAME, 'g'), appName)
+    .replace(new RegExp(DEFAULT_APP_NAMES.join('|'), 'g'), appName)
     .replace(
-      new RegExp(DEFAULT_APP_NAME.toLowerCase(), 'g'),
+      new RegExp(
+        DEFAULT_APP_NAMES.map(defaultAppName =>
+          defaultAppName.toLowerCase()
+        ).join('|'),
+        'g'
+      ),
       appName.toLowerCase()
     )
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

There was some sort of change when generating releases that caused the diff to change as following:

![image](https://user-images.githubusercontent.com/6207220/139592793-e3929856-b6e0-4715-bf67-878bcb5e571f.png)

Which led `upgrade-helper` to show the header as:

![image](https://user-images.githubusercontent.com/6207220/139592811-39b60f99-5e5e-4ed8-8c39-6cb4c5c20447.png)

It seems like the lib we use for parsing diff doesn't like the lack of those initial characters so I had to add some replaces here and there as well as maintain the `RnDiffApp` replace for the previous versions.

## Test Plan

- Open the dev preview;
- Make sure that the paths are rendering correctly without the leading `RnDiffApp` but still using in specific places (such as `RnDiffApp.xcodeproj`);
- Set a different app name;
- Make sure that it renders correctly with the different app name.

## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
