### PR TITLE
Add option to specify app language for react-native-windows

### DIFF
--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -33,6 +33,7 @@ const scrollToRef = ref => ref.current.scrollIntoView({ behavior: 'smooth' })
 
 const DiffViewer = ({
   packageName,
+  language,
   fromVersion,
   toVersion,
   shouldShowDiff,
@@ -43,6 +44,7 @@ const DiffViewer = ({
   const { isLoading, isDone, diff } = useFetchDiff({
     shouldShowDiff,
     packageName,
+    language,
     fromVersion,
     toVersion
   })

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -153,7 +153,9 @@ const doesVersionExist = ({ version, allVersions, minVersion }) => {
 
 const updateURLVersions = ({
   packageName,
+  language,
   isPackageNameDefinedInURL,
+  isLanguageDefinedInURL,
   fromVersion,
   toVersion
 }) => {
@@ -162,17 +164,20 @@ const updateURLVersions = ({
   const packageNameInURL = isPackageNameDefinedInURL
     ? `&package=${packageName}`
     : ''
+  const languageInURL = isLanguageDefinedInURL ? `&language=${language}` : ''
 
   window.history.replaceState(
     null,
     null,
-    `${pageURL}${newURL}${packageNameInURL}`
+    `${pageURL}${newURL}${packageNameInURL}${languageInURL}`
   )
 }
 
 const VersionSelector = ({
   packageName,
+  language,
   isPackageNameDefinedInURL,
+  isLanguageDefinedInURL,
   showDiff,
   showReleaseCandidates
 }) => {
@@ -299,7 +304,9 @@ const VersionSelector = ({
 
     updateURLVersions({
       packageName,
+      language,
       isPackageNameDefinedInURL,
+      isLanguageDefinedInURL,
       fromVersion: localFromVersion,
       toVersion: localToVersion
     })

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -9,6 +9,7 @@ import Settings from '../common/Settings'
 import { homepage } from '../../../package.json'
 import logo from '../../assets/logo.svg'
 import { SHOW_LATEST_RCS } from '../../utils'
+import { useGetLanguageFromURL } from '../../hooks/get-language-from-url'
 import { useGetPackageNameFromURL } from '../../hooks/get-package-name-from-url'
 import { PACKAGE_NAMES } from '../../constants'
 import { TroubleshootingGuidesButton } from '../common/TroubleshootingGuidesButton'
@@ -54,6 +55,7 @@ const StarButton = styled(({ className, ...props }) => (
 
 const Home = () => {
   const { packageName, isPackageNameDefinedInURL } = useGetPackageNameFromURL()
+  const { language, isLanguageDefinedInURL } = useGetLanguageFromURL()
   const [fromVersion, setFromVersion] = useState('')
   const [toVersion, setToVersion] = useState('')
   const [shouldShowDiff, setShouldShowDiff] = useState(false)
@@ -124,7 +126,9 @@ const Home = () => {
           showDiff={handleShowDiff}
           showReleaseCandidates={settings[SHOW_LATEST_RCS]}
           packageName={packageName}
+          language={language}
           isPackageNameDefinedInURL={isPackageNameDefinedInURL}
+          isLanguageDefinedInURL={isLanguageDefinedInURL}
         />
       </Container>
 
@@ -134,6 +138,7 @@ const Home = () => {
         toVersion={toVersion}
         appName={appName}
         packageName={packageName}
+        language={language}
       />
     </Page>
   )

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,11 @@ export const PACKAGE_NAMES = {
   RNW: 'react-native-windows'
 }
 
+export const LANGUAGE_NAMES = {
+  CPP: 'cpp',
+  CS: 'cs'
+}
+
 export const RN_DIFF_REPOSITORIES = {
   [PACKAGE_NAMES.RN]: 'react-native-community/rn-diff-purge',
   [PACKAGE_NAMES.RNW]: 'acoates-ms/rnw-diff'

--- a/src/hooks/fetch-diff.js
+++ b/src/hooks/fetch-diff.js
@@ -10,6 +10,7 @@ const movePackageJsonToTop = parsedDiff =>
 export const useFetchDiff = ({
   shouldShowDiff,
   packageName,
+  language,
   fromVersion,
   toVersion
 }) => {
@@ -23,7 +24,7 @@ export const useFetchDiff = ({
       setIsDone(false)
 
       const [response] = await Promise.all([
-        fetch(getDiffURL({ packageName, fromVersion, toVersion })),
+        fetch(getDiffURL({ packageName, language, fromVersion, toVersion })),
         delay(300)
       ])
 
@@ -40,7 +41,7 @@ export const useFetchDiff = ({
     if (shouldShowDiff) {
       fetchDiff()
     }
-  }, [shouldShowDiff, packageName, fromVersion, toVersion])
+  }, [shouldShowDiff, packageName, language, fromVersion, toVersion])
 
   return {
     isLoading,

--- a/src/hooks/get-language-from-url.js
+++ b/src/hooks/get-language-from-url.js
@@ -1,0 +1,20 @@
+import { LANGUAGE_NAMES } from '../constants'
+
+export const useGetLanguageFromURL = () => {
+  const urlParams = new URLSearchParams(window.location.search)
+
+  const languageFromURL = urlParams.get('language')
+  const languageNames = Object.values(LANGUAGE_NAMES)
+
+  if (!languageFromURL || !languageNames.includes(languageFromURL)) {
+    return {
+      language: LANGUAGE_NAMES.CPP,
+      isLanguageDefinedInURL: false
+    }
+  }
+
+  return {
+    language: languageFromURL,
+    isLanguageDefinedInURL: true
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,14 +15,15 @@ export const getReleasesFileURL = ({ packageName }) =>
     packageName
   })}/master/RELEASES`
 
-export const getDiffURL = ({ packageName, fromVersion, toVersion }) =>
+export const getDiffURL = ({ packageName, language, fromVersion, toVersion }) =>
   `https://raw.githubusercontent.com/${getRNDiffRepository({
     packageName
-  })}/diffs/diffs/${fromVersion}..${toVersion}.diff`
+  })}/diffs/diffs/${language}/${fromVersion}..${toVersion}.diff`
 
 // `path` must contain `RnDiffApp` prefix
-export const getBinaryFileURL = ({ packageName, version, path }) => {
-  const branch = packageName === PACKAGE_NAMES.RNW ? `cpp/${version}` : version
+export const getBinaryFileURL = ({ packageName, language, version, path }) => {
+  const branch =
+    packageName === PACKAGE_NAMES.RNW ? `${language}/${version}` : version
 
   return `https://github.com/${getRNDiffRepository({
     packageName

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,10 +15,18 @@ export const getReleasesFileURL = ({ packageName }) =>
     packageName
   })}/master/RELEASES`
 
-export const getDiffURL = ({ packageName, language, fromVersion, toVersion }) =>
-  `https://raw.githubusercontent.com/${getRNDiffRepository({
+export const getDiffURL = ({
+  packageName,
+  language,
+  fromVersion,
+  toVersion
+}) => {
+  const languageDir = packageName === PACKAGE_NAMES.RNW ? `${language}/` : ''
+
+  return `https://raw.githubusercontent.com/${getRNDiffRepository({
     packageName
-  })}/diffs/diffs/${language}/${fromVersion}..${toVersion}.diff`
+  })}/diffs/diffs/${languageDir}${fromVersion}..${toVersion}.diff`
+}
 
 // `path` must contain `RnDiffApp` prefix
 export const getBinaryFileURL = ({ packageName, language, version, path }) => {


### PR DESCRIPTION
# Summary

react-native-windows supports applications written in C++ or in CSharp.  The current version of upgrade helper only allows users to view the diffs for C++ applications.  This change adds an additional URL parameter for language, which can be either `cpp`, or `cs`.  This will change which set of diffs get loaded - either the ones for C++ or CSharp apps.

## Test Plan

Ran the test site, with package=react-native-windows.  package=react-native-windows&language=cpp, package=react-native-windows&language=cs, and also react-native-windows&language=notreallang (to verify invalid input case).

Also tested language property with package=react-native to verify no effect.

## What are the steps to reproduce?

## Checklist

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
