### PR TITLE
Add react-native-macos support and UI to switch packageName/Language

### DIFF
--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -50,19 +50,19 @@ const Settings = ({
       onChangeAppName(newAppName)
     }
 
+    const processedNewLanguage =
+      newLanguage !== language && newPackageName === PACKAGE_NAMES.RNW
+        ? newLanguage
+        : LANGUAGE_NAMES.CPP
+
     if (
       !visibility &&
-      (newPackageName !== packageName || newLanguage !== language)
+      (newPackageName !== packageName || processedNewLanguage !== language)
     ) {
       onChangePackageNameAndLanguage({
         newPackageName:
           newPackageName !== packageName ? newPackageName : undefined,
-        newLanguage:
-          newLanguage !== language && newPackageName === PACKAGE_NAMES.RNW
-            ? newLanguage
-              ? newLanguage
-              : LANGUAGE_NAMES.CPP
-            : undefined
+        newLanguage: processedNewLanguage
       })
     }
   }
@@ -117,9 +117,7 @@ const Settings = ({
                     <Radio.Button value="cs">C#</Radio.Button>
                   </Radio.Group>
                 </Radio>
-                {/* In the future... other platforms:
                 <Radio value={PACKAGE_NAMES.RNM}>react-native-macos</Radio>
-                 */}
               </PackagesGroupContainer>
             </Radio.Group>
           </PlatformsContainer>

--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -3,7 +3,7 @@ import { Popover, Button, Checkbox, Input, Radio } from 'antd'
 import { SHOW_LATEST_RCS } from '../../utils'
 import styled from '@emotion/styled'
 import { WindowsFilled } from '@ant-design/icons'
-import { PACKAGE_NAMES } from '../../constants'
+import { PACKAGE_NAMES, LANGUAGE_NAMES } from '../../constants'
 
 const InputContainer = styled.div({
   marginTop: '16px'
@@ -50,13 +50,18 @@ const Settings = ({
       onChangeAppName(newAppName)
     }
 
-    if (newPackageName !== packageName || newLanguage !== language) {
+    if (
+      !visibility &&
+      (newPackageName !== packageName || newLanguage !== language)
+    ) {
       onChangePackageNameAndLanguage({
         newPackageName:
           newPackageName !== packageName ? newPackageName : undefined,
         newLanguage:
           newLanguage !== language && newPackageName === PACKAGE_NAMES.RNW
             ? newLanguage
+              ? newLanguage
+              : LANGUAGE_NAMES.CPP
             : undefined
       })
     }

--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
-import { Popover, Button, Checkbox, Input } from 'antd'
+import { Popover, Button, Checkbox, Input, Radio } from 'antd'
 import { SHOW_LATEST_RCS } from '../../utils'
 import styled from '@emotion/styled'
+import { WindowsFilled } from '@ant-design/icons'
+import { PACKAGE_NAMES } from '../../constants'
 
 const InputContainer = styled.div({
   marginTop: '16px'
@@ -15,15 +17,48 @@ const SettingsIcon = styled(props => <span {...props}>⚙️</span>)`
   font-family: initial;
 `
 
-const Settings = ({ handleSettingsChange, appName, onChangeAppName }) => {
+const PlatformsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  margin-top: 12px;
+`
+
+const PackagesGroupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+`
+
+const Settings = ({
+  handleSettingsChange,
+  packageName,
+  language,
+  onChangePackageNameAndLanguage,
+  appName,
+  onChangeAppName
+}) => {
   const [popoverVisibility, setVisibility] = useState(false)
   const [newAppName, setNewAppName] = useState(appName)
+  const [newPackageName, setNewPackageName] = useState(packageName)
+  const [newLanguage, setNewLanguage] = useState(language)
 
   const handleClickChange = visibility => {
     setVisibility(visibility)
 
     if (newAppName !== appName) {
       onChangeAppName(newAppName)
+    }
+
+    if (newPackageName !== packageName || newLanguage !== language) {
+      onChangePackageNameAndLanguage({
+        newPackageName:
+          newPackageName !== packageName ? newPackageName : undefined,
+        newLanguage:
+          newLanguage !== language && newPackageName === PACKAGE_NAMES.RNW
+            ? newLanguage
+            : undefined
+      })
     }
   }
 
@@ -48,6 +83,41 @@ const Settings = ({ handleSettingsChange, appName, onChangeAppName }) => {
               placeholder="MyAwesomeApp"
             />
           </InputContainer>
+          <PlatformsContainer>
+            <h5>Upgrading another platform?</h5>
+            <Radio.Group
+              value={newPackageName}
+              onChange={e => setNewPackageName(e.target.value)}
+            >
+              <PackagesGroupContainer>
+                <Radio value={PACKAGE_NAMES.RN}>react-native</Radio>
+                <Radio value={PACKAGE_NAMES.RNW}>
+                  <Radio.Group
+                    size="small"
+                    value={
+                      newPackageName === PACKAGE_NAMES.RNW
+                        ? newLanguage
+                        : undefined
+                    }
+                    onChange={e => {
+                      setNewPackageName(PACKAGE_NAMES.RNW)
+                      setNewLanguage(e.target.value)
+                    }}
+                  >
+                    <span style={{ marginRight: 10 }}>
+                      react-native-windows
+                      <WindowsFilled style={{ margin: 5 }} />
+                    </span>
+                    <Radio.Button value="cpp">C++</Radio.Button>
+                    <Radio.Button value="cs">C#</Radio.Button>
+                  </Radio.Group>
+                </Radio>
+                {/* In the future... other platforms:
+                <Radio value={PACKAGE_NAMES.RNM}>react-native-macos</Radio>
+                 */}
+              </PackagesGroupContainer>
+            </Radio.Group>
+          </PlatformsContainer>
         </>
       }
       trigger="click"

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -152,9 +152,14 @@ class UsefulContentSection extends Component {
   getChangelog = ({ version }) => {
     const { packageName, toVersion } = this.props
 
-    if (packageName === PACKAGE_NAMES.RNW) {
+    if (
+      packageName === PACKAGE_NAMES.RNW ||
+      packageName === PACKAGE_NAMES.RNM
+    ) {
       return {
-        title: `React Native Windows ${toVersion} changelog`,
+        title: `React Native ${
+          packageName === PACKAGE_NAMES.RNW ? 'Windows' : 'macOS'
+        } ${toVersion} changelog`,
         url: getChangelogURL({
           packageName,
           version: toVersion

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -6,6 +6,7 @@ import queryString from 'query-string'
 import { Select } from './'
 import UpgradeButton from './UpgradeButton'
 import { useFetchReleaseVersions } from '../../hooks/fetch-release-versions'
+import { updateURL } from '../../utils/update-url'
 
 export const testIDs = {
   fromVersionSelector: 'fromVersionSelector',
@@ -151,28 +152,6 @@ const doesVersionExist = ({ version, allVersions, minVersion }) => {
   }
 }
 
-const updateURLVersions = ({
-  packageName,
-  language,
-  isPackageNameDefinedInURL,
-  isLanguageDefinedInURL,
-  fromVersion,
-  toVersion
-}) => {
-  const pageURL = window.location.href.replace(window.location.search, '')
-  const newURL = `?from=${fromVersion}&to=${toVersion}`
-  const packageNameInURL = isPackageNameDefinedInURL
-    ? `&package=${packageName}`
-    : ''
-  const languageInURL = isLanguageDefinedInURL ? `&language=${language}` : ''
-
-  window.history.replaceState(
-    null,
-    null,
-    `${pageURL}${newURL}${packageNameInURL}${languageInURL}`
-  )
-}
-
 const VersionSelector = ({
   packageName,
   language,
@@ -302,7 +281,7 @@ const VersionSelector = ({
       toVersion: localToVersion
     })
 
-    updateURLVersions({
+    updateURL({
       packageName,
       language,
       isPackageNameDefinedInURL,
@@ -317,7 +296,7 @@ const VersionSelector = ({
       <Selectors>
         <FromVersionSelector
           data-testid={testIDs.fromVersionSelector}
-          title="What's your current React Native version?"
+          title={`What's your current ${packageName} version?`}
           loading={isLoading}
           value={localFromVersion}
           options={fromVersionList}

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -156,7 +156,6 @@ const VersionSelector = ({
   packageName,
   language,
   isPackageNameDefinedInURL,
-  isLanguageDefinedInURL,
   showDiff,
   showReleaseCandidates
 }) => {
@@ -285,7 +284,6 @@ const VersionSelector = ({
       packageName,
       language,
       isPackageNameDefinedInURL,
-      isLanguageDefinedInURL,
       fromVersion: localFromVersion,
       toVersion: localToVersion
     })

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -104,11 +104,14 @@ const Home = () => {
         isPackageNameDefinedInURL || newPackageName !== undefined,
       isLanguageDefinedInURL:
         isLanguageDefinedInURL || newLanguage !== undefined,
-      fromVersion,
-      toVersion
+      toVersion: '',
+      fromVersion: ''
     })
     setPackageName(localPackageName)
     setLanguage(localLanguage)
+    setFromVersion('')
+    setToVersion('')
+    setShouldShowDiff(false)
   }
 
   const handleSettingsChange = settingsValues => {
@@ -164,7 +167,6 @@ const Home = () => {
           isLanguageDefinedInURL={isLanguageDefinedInURL}
         />
       </Container>
-
       <DiffViewer
         shouldShowDiff={shouldShowDiff}
         fromVersion={fromVersion}

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -59,10 +59,7 @@ const Home = () => {
     packageName: defaultPackageName,
     isPackageNameDefinedInURL
   } = useGetPackageNameFromURL()
-  const {
-    language: defaultLanguage,
-    isLanguageDefinedInURL
-  } = useGetLanguageFromURL()
+  const defaultLanguage = useGetLanguageFromURL()
   const [packageName, setPackageName] = useState(defaultPackageName)
   const [language, setLanguage] = useState(defaultLanguage)
   const [fromVersion, setFromVersion] = useState('')
@@ -96,14 +93,13 @@ const Home = () => {
   }) => {
     let localPackageName =
       newPackageName === undefined ? packageName : newPackageName
-    let localLanguage = newLanguage === undefined ? newLanguage : newLanguage
+    let localLanguage = newLanguage === undefined ? language : newLanguage
+
     updateURL({
       packageName: localPackageName,
       language: localLanguage,
       isPackageNameDefinedInURL:
         isPackageNameDefinedInURL || newPackageName !== undefined,
-      isLanguageDefinedInURL:
-        isLanguageDefinedInURL || newLanguage !== undefined,
       toVersion: '',
       fromVersion: ''
     })
@@ -159,12 +155,12 @@ const Home = () => {
         </TitleContainer>
 
         <VersionSelector
+          key={packageName}
           showDiff={handleShowDiff}
           showReleaseCandidates={settings[SHOW_LATEST_RCS]}
           packageName={packageName}
           language={language}
           isPackageNameDefinedInURL={isPackageNameDefinedInURL}
-          isLanguageDefinedInURL={isLanguageDefinedInURL}
         />
       </Container>
       <DiffViewer

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -13,6 +13,7 @@ import { useGetLanguageFromURL } from '../../hooks/get-language-from-url'
 import { useGetPackageNameFromURL } from '../../hooks/get-package-name-from-url'
 import { PACKAGE_NAMES } from '../../constants'
 import { TroubleshootingGuidesButton } from '../common/TroubleshootingGuidesButton'
+import { updateURL } from '../../utils/update-url'
 
 const Page = styled.div`
   display: flex;
@@ -54,8 +55,16 @@ const StarButton = styled(({ className, ...props }) => (
 `
 
 const Home = () => {
-  const { packageName, isPackageNameDefinedInURL } = useGetPackageNameFromURL()
-  const { language, isLanguageDefinedInURL } = useGetLanguageFromURL()
+  const {
+    packageName: defaultPackageName,
+    isPackageNameDefinedInURL
+  } = useGetPackageNameFromURL()
+  const {
+    language: defaultLanguage,
+    isLanguageDefinedInURL
+  } = useGetLanguageFromURL()
+  const [packageName, setPackageName] = useState(defaultPackageName)
+  const [language, setLanguage] = useState(defaultLanguage)
   const [fromVersion, setFromVersion] = useState('')
   const [toVersion, setToVersion] = useState('')
   const [shouldShowDiff, setShouldShowDiff] = useState(false)
@@ -79,6 +88,27 @@ const Home = () => {
     setFromVersion(fromVersion)
     setToVersion(toVersion)
     setShouldShowDiff(true)
+  }
+
+  const handlePackageNameAndLanguageChange = ({
+    newPackageName,
+    newLanguage
+  }) => {
+    let localPackageName =
+      newPackageName === undefined ? packageName : newPackageName
+    let localLanguage = newLanguage === undefined ? newLanguage : newLanguage
+    updateURL({
+      packageName: localPackageName,
+      language: localLanguage,
+      isPackageNameDefinedInURL:
+        isPackageNameDefinedInURL || newPackageName !== undefined,
+      isLanguageDefinedInURL:
+        isLanguageDefinedInURL || newLanguage !== undefined,
+      fromVersion,
+      toVersion
+    })
+    setPackageName(localPackageName)
+    setLanguage(localLanguage)
   }
 
   const handleSettingsChange = settingsValues => {
@@ -118,6 +148,9 @@ const Home = () => {
           <Settings
             handleSettingsChange={handleSettingsChange}
             appName={appName}
+            packageName={packageName}
+            onChangePackageNameAndLanguage={handlePackageNameAndLanguageChange}
+            language={language}
             onChangeAppName={setAppName}
           />
         </TitleContainer>

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@ export const DEFAULT_APP_NAME = 'RnDiffApp'
 
 export const PACKAGE_NAMES = {
   RN: 'react-native',
+  RNM: 'react-native-macos',
   RNW: 'react-native-windows'
 }
 
@@ -12,12 +13,15 @@ export const LANGUAGE_NAMES = {
 
 export const RN_DIFF_REPOSITORIES = {
   [PACKAGE_NAMES.RN]: 'react-native-community/rn-diff-purge',
+  [PACKAGE_NAMES.RNM]: 'acoates-ms/rnw-diff',
   [PACKAGE_NAMES.RNW]: 'acoates-ms/rnw-diff'
 }
 
 export const RN_CHANGELOG_URLS = {
   [PACKAGE_NAMES.RN]:
     'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md',
+  [PACKAGE_NAMES.RNM]:
+    'https://github.com/microsoft/react-native-macos/releases/tag/',
   [PACKAGE_NAMES.RNW]:
     'https://github.com/microsoft/react-native-windows/releases/tag/react-native-windows_'
 }

--- a/src/hooks/get-language-from-url.js
+++ b/src/hooks/get-language-from-url.js
@@ -7,14 +7,8 @@ export const useGetLanguageFromURL = () => {
   const languageNames = Object.values(LANGUAGE_NAMES)
 
   if (!languageFromURL || !languageNames.includes(languageFromURL)) {
-    return {
-      language: LANGUAGE_NAMES.CPP,
-      isLanguageDefinedInURL: false
-    }
+    return LANGUAGE_NAMES.CPP
   }
 
-  return {
-    language: languageFromURL,
-    isLanguageDefinedInURL: true
-  }
+  return languageFromURL
 }

--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -2,6 +2,7 @@ import { PACKAGE_NAMES } from '../constants'
 
 const versionsWithContent = {
   [PACKAGE_NAMES.RN]: ['0.64', '0.62', '0.61', '0.60', '0.59', '0.58', '0.57'],
+  [PACKAGE_NAMES.RNM]: [],
   [PACKAGE_NAMES.RNW]: []
 }
 
@@ -13,5 +14,6 @@ const getReleaseVersionFiles = packageName =>
 
 export default {
   [PACKAGE_NAMES.RN]: getReleaseVersionFiles(PACKAGE_NAMES.RN),
+  [PACKAGE_NAMES.RNM]: getReleaseVersionFiles(PACKAGE_NAMES.RNM),
   [PACKAGE_NAMES.RNW]: getReleaseVersionFiles(PACKAGE_NAMES.RNW)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ const getRNDiffRepository = ({ packageName }) =>
 export const getReleasesFileURL = ({ packageName }) =>
   `https://raw.githubusercontent.com/${getRNDiffRepository({
     packageName
-  })}/master/RELEASES`
+  })}/master/${packageName === PACKAGE_NAMES.RNM ? 'RELEASES_MAC' : 'RELEASES'}`
 
 export const getDiffURL = ({
   packageName,
@@ -21,7 +21,12 @@ export const getDiffURL = ({
   fromVersion,
   toVersion
 }) => {
-  const languageDir = packageName === PACKAGE_NAMES.RNW ? `${language}/` : ''
+  const languageDir =
+    packageName === PACKAGE_NAMES.RNM
+      ? 'mac/'
+      : packageName === PACKAGE_NAMES.RNW
+      ? `${language}/`
+      : ''
 
   return `https://raw.githubusercontent.com/${getRNDiffRepository({
     packageName
@@ -31,7 +36,11 @@ export const getDiffURL = ({
 // `path` must contain `RnDiffApp` prefix
 export const getBinaryFileURL = ({ packageName, language, version, path }) => {
   const branch =
-    packageName === PACKAGE_NAMES.RNW ? `${language}/${version}` : version
+    packageName === PACKAGE_NAMES.RNM
+      ? `mac/${version}`
+      : packageName === PACKAGE_NAMES.RNW
+      ? `${language}/${version}`
+      : version
 
   return `https://github.com/${getRNDiffRepository({
     packageName
@@ -77,7 +86,7 @@ export const getVersionsContentInDiff = ({
 }
 
 export const getChangelogURL = ({ version, packageName }) => {
-  if (packageName === PACKAGE_NAMES.RNW) {
+  if (packageName === PACKAGE_NAMES.RNW || packageName === PACKAGE_NAMES.RNM) {
     return `${RN_CHANGELOG_URLS[packageName]}v${version}`
   }
 

--- a/src/utils/update-url.js
+++ b/src/utils/update-url.js
@@ -1,0 +1,24 @@
+export function updateURL({
+  packageName,
+  language,
+  isPackageNameDefinedInURL,
+  isLanguageDefinedInURL,
+  fromVersion,
+  toVersion
+}) {
+  const pageURL = window.location.href.replace(window.location.search, '')
+  const newURL = `?from=${fromVersion}&to=${toVersion}`
+  const packageNameInURL = isPackageNameDefinedInURL
+    ? `&package=${packageName}`
+    : ''
+  const languageInURL =
+    isLanguageDefinedInURL && language !== undefined
+      ? `&language=${language}`
+      : ''
+
+  window.history.replaceState(
+    null,
+    null,
+    `${pageURL}${newURL}${packageNameInURL}${languageInURL}`
+  )
+}

--- a/src/utils/update-url.js
+++ b/src/utils/update-url.js
@@ -1,8 +1,9 @@
+import { PACKAGE_NAMES } from '../constants'
+
 export function updateURL({
   packageName,
   language,
   isPackageNameDefinedInURL,
-  isLanguageDefinedInURL,
   fromVersion,
   toVersion
 }) {
@@ -16,9 +17,7 @@ export function updateURL({
     ? `&package=${packageName}`
     : ''
   const languageInURL =
-    isLanguageDefinedInURL && language !== undefined
-      ? `&language=${language}`
-      : ''
+    packageName === PACKAGE_NAMES.RNW ? `&language=${language}` : ''
 
   window.history.replaceState(
     null,

--- a/src/utils/update-url.js
+++ b/src/utils/update-url.js
@@ -7,7 +7,11 @@ export function updateURL({
   toVersion
 }) {
   const pageURL = window.location.href.replace(window.location.search, '')
-  const newURL = `?from=${fromVersion}&to=${toVersion}`
+
+  const newURL =
+    fromVersion !== '' || toVersion !== ''
+      ? `?from=${fromVersion}&to=${toVersion}`
+      : '?'
   const packageNameInURL = isPackageNameDefinedInURL
     ? `&package=${packageName}`
     : ''


### PR DESCRIPTION

# Summary

Adds UI to the settings popover to allows users to switch between `react-native` and `react-native-windows`, and to switch between C++ and C# within `react-native-windows`.

Here is what the new settings popover looks like:
![image](https://user-images.githubusercontent.com/30809111/141023487-46c73176-57db-43b4-8bb8-cc5be71fc500.png)

## Test Plan

Ran through the site starting with various values of `packageName` and `language` in the URL.  Try changing the package name back and forth in the settings.  Try changing the language when `packageName=react-native-windows`.  Try changing it when in `packageName=react-native`  Try changing back to `react-native` after switching the language.

## What are the steps to reproduce?

Just load the site and hit the settings icon in the top right.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
