### PR TITLE
fix top section layout on mobile

### DIFF
--- a/src/components/common/TroubleshootingGuidesButton.js
+++ b/src/components/common/TroubleshootingGuidesButton.js
@@ -18,7 +18,6 @@ const Icon = styled.span`
 const Button = styled(AntdButton)`
   width: 32px;
   padding: 0;
-  margin-right: 8px;
   color: initial;
 `
 

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -7,6 +7,7 @@ import { Select } from './'
 import UpgradeButton from './UpgradeButton'
 import { useFetchReleaseVersions } from '../../hooks/fetch-release-versions'
 import { updateURL } from '../../utils/update-url'
+import { deviceSizes } from '../../utils/device-sizes'
 
 export const testIDs = {
   fromVersionSelector: 'fromVersionSelector',
@@ -15,11 +16,20 @@ export const testIDs = {
 
 const Selectors = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
+  gap: 15px;
+
+  @media ${deviceSizes.tablet} {
+    flex-direction: row;
+    gap: 0;
+  }
 `
 
 const FromVersionSelector = styled(Select)`
-  padding-right: 5px;
+  @media ${deviceSizes.tablet} {
+    padding-right: 5px;
+  }
 `
 
 const ToVersionSelector = styled(({ popover, ...props }) =>
@@ -31,7 +41,9 @@ const ToVersionSelector = styled(({ popover, ...props }) =>
     <Select {...props} />
   )
 )`
-  padding-left: 5px;
+  @media ${deviceSizes.tablet} {
+    padding-left: 5px;
+  }
 `
 
 const getVersionsInURL = () => {

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -14,6 +14,7 @@ import { useGetPackageNameFromURL } from '../../hooks/get-package-name-from-url'
 import { PACKAGE_NAMES } from '../../constants'
 import { TroubleshootingGuidesButton } from '../common/TroubleshootingGuidesButton'
 import { updateURL } from '../../utils/update-url'
+import { deviceSizes } from '../../utils/device-sizes'
 
 const Page = styled.div`
   display: flex;
@@ -29,19 +30,43 @@ const Container = styled(Card)`
   border-color: #e8e8e8;
 `
 
-const TitleContainer = styled.div`
+const HeaderContainer = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: center;
+
+  @media ${deviceSizes.tablet} {
+    flex-direction: row;
+  }
 `
 
 const LogoImg = styled.img`
-  width: 100px;
+  width: 50px;
   margin-bottom: 15px;
+
+  @media ${deviceSizes.tablet} {
+    width: 100px;
+  }
 `
 
 const TitleHeader = styled.h1`
   margin: 0;
   margin-left: 15px;
+`
+
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+`
+
+const SettingsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+  margin-bottom: 8px;
+  flex: 1;
 `
 
 const StarButton = styled(({ className, ...props }) => (
@@ -122,37 +147,42 @@ const Home = () => {
   return (
     <Page>
       <Container>
-        <TitleContainer>
-          <LogoImg
-            alt="React Native Upgrade Helper logo"
-            title="React Native Upgrade Helper logo"
-            src={logo}
-          />
+        <HeaderContainer>
+          <TitleContainer>
+            <LogoImg
+              alt="React Native Upgrade Helper logo"
+              title="React Native Upgrade Helper logo"
+              src={logo}
+            />
+            <a href={homepage}>
+              <TitleHeader>React Native Upgrade Helper</TitleHeader>
+            </a>
+          </TitleContainer>
 
-          <a href={homepage}>
-            <TitleHeader>React Native Upgrade Helper</TitleHeader>
-          </a>
-
-          <StarButton
-            href="https://github.com/react-native-community/upgrade-helper"
-            data-icon="octicon-star"
-            data-show-count="true"
-            aria-label="Star react-native-community/upgrade-helper on GitHub"
-          >
-            Star
-          </StarButton>
-
-          {packageName === PACKAGE_NAMES.RN && <TroubleshootingGuidesButton />}
-
-          <Settings
-            handleSettingsChange={handleSettingsChange}
-            appName={appName}
-            packageName={packageName}
-            onChangePackageNameAndLanguage={handlePackageNameAndLanguageChange}
-            language={language}
-            onChangeAppName={setAppName}
-          />
-        </TitleContainer>
+          <SettingsContainer>
+            <StarButton
+              href="https://github.com/react-native-community/upgrade-helper"
+              data-icon="octicon-star"
+              data-show-count="true"
+              aria-label="Star react-native-community/upgrade-helper on GitHub"
+            >
+              Star
+            </StarButton>
+            {packageName === PACKAGE_NAMES.RN && (
+              <TroubleshootingGuidesButton />
+            )}
+            <Settings
+              handleSettingsChange={handleSettingsChange}
+              appName={appName}
+              packageName={packageName}
+              onChangePackageNameAndLanguage={
+                handlePackageNameAndLanguageChange
+              }
+              language={language}
+              onChangeAppName={setAppName}
+            />
+          </SettingsContainer>
+        </HeaderContainer>
 
         <VersionSelector
           key={packageName}

--- a/src/utils/device-sizes.js
+++ b/src/utils/device-sizes.js
@@ -1,0 +1,3 @@
+export const deviceSizes = {
+  tablet: '(min-width: 768px)'
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Haven't created an issue. It fixes the mobile layout for the top section in the application, excluding the diff viewer.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

Changes the layout for devices below 768px width. Portrait iPads get the normal layout.

The only change visible on desktop devices is the gap between troubleshooting and settings which is `15px` instead of `8px`. 

No changes in dependencies.

Tested using iPhone 11 Pro and Chrome, Firefox, Safari on macOS 11.6.1.

The popper.js arrow is not in the correct position. May have to do some extra tweaks for that in a separate PR.

<table>
<tr>
	<th>Before</th>
	<th>After</th>
</tr>
<tr>
	<td><img width="496" alt="before" src="https://user-images.githubusercontent.com/4541038/143032369-024c47f4-36fb-43b3-bb21-72a75c41566d.png"></td>
	<td><img width="490" alt="after" src="https://user-images.githubusercontent.com/4541038/143032402-d70c4cbd-4ee8-42a7-9b92-c8883b97c2de.png"></td>
</tr>
<tr>
	<td><img width="530" alt="before2" src="https://user-images.githubusercontent.com/4541038/143034112-c293e536-ac84-4a0f-a1e0-e716a5779c5a.png"></td>
	<td><img width="544" alt="after2" src="https://user-images.githubusercontent.com/4541038/143034119-6082038c-389e-4efb-ab93-8c8e5f77c2d2.png"></td>
</tr>
</table>

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## What are the steps to reproduce?

1. `yarn start`
2. Check UI

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
