### PR TITLE
Highlight new arch changes for 0.68

### DIFF
--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -1,7 +1,16 @@
 import { PACKAGE_NAMES } from '../constants'
 
 const versionsWithContent = {
-  [PACKAGE_NAMES.RN]: ['0.64', '0.62', '0.61', '0.60', '0.59', '0.58', '0.57'],
+  [PACKAGE_NAMES.RN]: [
+    '0.68',
+    '0.64',
+    '0.62',
+    '0.61',
+    '0.60',
+    '0.59',
+    '0.58',
+    '0.57'
+  ],
   [PACKAGE_NAMES.RNM]: [],
   [PACKAGE_NAMES.RNW]: []
 }

--- a/src/releases/react-native/0.68.js
+++ b/src/releases/react-native/0.68.js
@@ -1,0 +1,108 @@
+import React, { Fragment } from 'react'
+
+const newArchitectureFiles = [
+  'android/app/src/main/java/com/rndiffapp/newarchitecture/MainApplicationReactNativeHost.java',
+  'android/app/src/main/java/com/rndiffapp/newarchitecture/components/MainComponentsRegistry.java',
+  'android/app/src/main/java/com/rndiffapp/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java',
+  'android/app/src/main/jni/MainApplicationModuleProvider.h',
+  'android/app/src/main/jni/MainComponentsRegistry.cpp',
+  'android/app/src/main/jni/Android.mk',
+  'android/app/src/main/jni/MainApplicationModuleProvider.cpp',
+  'android/app/src/main/jni/MainApplicationTurboModuleManagerDelegate.cpp',
+  'android/app/src/main/jni/MainApplicationTurboModuleManagerDelegate.h',
+  'android/app/src/main/jni/MainComponentsRegistry.h',
+  'android/app/src/main/jni/OnLoad.cpp'
+]
+
+export default {
+  usefulContent: {
+    description:
+      'React Native 0.68 includes preview of the New Architecture opt-in.',
+    links: [
+      {
+        title:
+          'See here to learn more about new architecture and how to enable it in your project',
+        url: 'TODO: link'
+      }
+    ]
+  },
+  comments: [
+    {
+      fileName: 'package.json',
+      lineNumber: 24,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          `react-native-gradle-plugin` is only required for Android new
+          architecture builds.
+        </Fragment>
+      )
+    },
+    {
+      fileName: 'package.json',
+      lineNumber: 30,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          `codegenConfig` field is only required for new architecture builds to
+          configure exposed libraries.
+        </Fragment>
+      )
+    },
+    {
+      fileName: 'android/app/build.gradle',
+      lineNumber: 142,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          `isNewArchitectureEnabled()` and related logic is optional if you are
+          not planning to upgrade to the new architecture.
+        </Fragment>
+      )
+    },
+    {
+      fileName: 'android/app/build.gradle',
+      lineNumber: 283,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          `isNewArchitectureEnabled()` and related logic is optional if you are
+          not planning to upgrade to the new architecture.
+        </Fragment>
+      )
+    },
+    {
+      fileName: 'android/app/src/main/java/com/rndiffapp/MainActivity.java',
+      lineNumber: 36,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          New delegate and enabling Fabric in `ReactRootView` is only required
+          for the new architecture builds.
+        </Fragment>
+      )
+    },
+    {
+      fileName: 'ios/RnDiffApp/AppDelegate.mm',
+      lineNumber: 9,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          Parts under `RCT_NEW_ARCH_ENABLED` are only required for the new
+          architecture builds.
+        </Fragment>
+      )
+    },
+    ...newArchitectureFiles.map(file => ({
+      fileName: file,
+
+      lineNumber: 1,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          This file is only required for the new architecture build.
+        </Fragment>
+      )
+    }))
+  ]
+}

--- a/src/releases/react-native/0.68.js
+++ b/src/releases/react-native/0.68.js
@@ -22,33 +22,11 @@ export default {
       {
         title:
           'See here to learn more about new architecture and how to enable it in your project',
-        url: 'TODO: link'
+        url: 'https://reactnative.dev/docs/next/new-architecture-intro'
       }
     ]
   },
   comments: [
-    {
-      fileName: 'package.json',
-      lineNumber: 24,
-      lineChangeType: 'add',
-      content: (
-        <Fragment>
-          `react-native-gradle-plugin` is only required for Android new
-          architecture builds.
-        </Fragment>
-      )
-    },
-    {
-      fileName: 'package.json',
-      lineNumber: 30,
-      lineChangeType: 'add',
-      content: (
-        <Fragment>
-          `codegenConfig` field is only required for new architecture builds to
-          configure exposed libraries.
-        </Fragment>
-      )
-    },
     {
       fileName: 'android/app/build.gradle',
       lineNumber: 142,

--- a/src/releases/react-native/0.68.js
+++ b/src/releases/react-native/0.68.js
@@ -100,7 +100,7 @@ export default {
       lineChangeType: 'add',
       content: (
         <Fragment>
-          This file is only required for the new architecture build.
+          This file is only required for the New Architecture setup.
         </Fragment>
       )
     }))


### PR DESCRIPTION
# Summary

Highlights new changes added for 0.68, indicating parts and files that are added/removed.
Note that the link in the header is not active yet, to be updated when the new arch playbook is merged.

## Test Plan

`yarn start` + tested the warnings in the browser

## Checklist
- [X] I tested this thoroughly
