### PR TITLE
Update RN CHANGELOG link to the new location

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -19,7 +19,7 @@ export const RN_DIFF_REPOSITORIES = {
 
 export const RN_CHANGELOG_URLS = {
   [PACKAGE_NAMES.RN]:
-    'https://github.com/react-native-community/releases/blob/master/CHANGELOG.md',
+    'https://github.com/facebook/react-native/blob/main/CHANGELOG.md',
   [PACKAGE_NAMES.RNM]:
     'https://github.com/microsoft/react-native-macos/releases/tag/',
   [PACKAGE_NAMES.RNW]:


### PR DESCRIPTION
# Summary

Link to the RN CHANGELOG in the "Useful content for upgrading" section is currently pointing to the [deprecated repo](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md). 
This PR updates this link to point to the [new location](https://github.com/facebook/react-native/blob/main/CHANGELOG.md)