### PR TITLE
adding an alert about dep-check, plus some refactoring

### DIFF
--- a/src/components/common/DepCheckAlert.js
+++ b/src/components/common/DepCheckAlert.js
@@ -9,10 +9,10 @@ const DepCheckAlert = () => (
     </Markdown>
     <br />
     <Markdown>
-      `dep-check` is a tool by Microsoft that helps your dependencies
-      management, aligning the main RN libraries on the version of RN used (find
-      out more in the [dedicated
-      documentation](https://microsoft.github.io/rnx-kit/docs/guides/dependency-management)).
+      `dep-check` is a **community** tool from Microsoft that automates dependency
+      management. It knows which RN package versions work well together and are 
+      compatible with your specific version of RN. It uses that knowledge to align dependencies,
+      keeping your app healthy and up-to-date. Find out more [here](https://microsoft.github.io/rnx-kit/docs/guides/dependency-management)).
     </Markdown>
     <br />
     <Markdown>

--- a/src/components/common/DepCheckAlert.js
+++ b/src/components/common/DepCheckAlert.js
@@ -5,7 +5,7 @@ const DepCheckAlert = () => (
   <>
     <Markdown>
       You can use the following command to kick off the upgrade: `npx
-      rnx-dep-check --set-version [major.minor]`.
+      @rnx-kit/dep-check --set-version [major.minor]`.
     </Markdown>
     <br />
     <Markdown>

--- a/src/components/common/DepCheckAlert.js
+++ b/src/components/common/DepCheckAlert.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import Markdown from './Markdown'
+
+const DepCheckAlert = () => (
+  <>
+    <Markdown>
+      You can use the following command to kick off the upgrade: `npx
+      rnx-dep-check --set-version [major.minor]`.
+    </Markdown>
+    <br />
+    <Markdown>
+      `dep-check` is a tool by Microsoft that helps your dependencies
+      management, aligning the main RN libraries on the version of RN used (find
+      out more in the [dedicated
+      documentation](https://microsoft.github.io/rnx-kit/docs/guides/dependency-management)).
+    </Markdown>
+    <br />
+    <Markdown>
+      You still need to do the other changes below and verify the changelogs of
+      the libraries that got upgraded.
+    </Markdown>
+  </>
+)
+
+export default DepCheckAlert

--- a/src/components/common/DepCheckAlert.js
+++ b/src/components/common/DepCheckAlert.js
@@ -9,15 +9,18 @@ const DepCheckAlert = () => (
     </Markdown>
     <br />
     <Markdown>
-      `dep-check` is a **community** tool from Microsoft that automates dependency
-      management. It knows which RN package versions work well together and are 
-      compatible with your specific version of RN. It uses that knowledge to align dependencies,
-      keeping your app healthy and up-to-date. Find out more [here](https://microsoft.github.io/rnx-kit/docs/guides/dependency-management)).
+      `dep-check` is an OSS tool from Microsoft that automates dependency
+      management. It knows which packages\* versions are compatible with your
+      specific version of RN, and it uses that knowledge to align dependencies,
+      keeping your app healthy and up-to-date\*\*. [Find out more
+      here](https://microsoft.github.io/rnx-kit/docs/guides/dependency-management).
     </Markdown>
     <br />
+    <Markdown>\* Not all packages are supported out-of-the-box.</Markdown>
+    <br />
     <Markdown>
-      You still need to do the other changes below and verify the changelogs of
-      the libraries that got upgraded.
+      \*\* You still need to do the other changes below and verify the
+      changelogs of the libraries that got upgraded.
     </Markdown>
   </>
 )

--- a/src/components/common/UpgradeSupportAlert.js
+++ b/src/components/common/UpgradeSupportAlert.js
@@ -24,7 +24,6 @@ const UpgradeSupportAlert = styled(props => (
     </span>
   </div>
 ))`
-  padding-top: 15px;
   span > a {
     color: #045dc1;
 

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -12,6 +12,7 @@ import {
 import UpgradeSupportAlert from './UpgradeSupportAlert'
 import AppNameWarning from './AppNameWarning'
 import UsefulLinks from './UsefulLinks'
+import DepCheckAlert from './DepCheckAlert'
 
 import { PACKAGE_NAMES } from '../../constants'
 
@@ -211,7 +212,7 @@ class UsefulContentSection extends Component {
               <UsefulLinks versions={versions} />
             ) : null}
 
-            <UpgradeSupportAlert />
+            <DepCheckAlert />
 
             <Separator />
 

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -1,16 +1,18 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import styled from '@emotion/styled'
 import { UpOutlined, DownOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
+import { motion } from 'framer-motion'
+
 import {
   getVersionsContentInDiff,
   getChangelogURL,
   getTransitionDuration
 } from '../../utils'
-import { Link } from './Markdown'
 import UpgradeSupportAlert from './UpgradeSupportAlert'
 import AppNameWarning from './AppNameWarning'
-import { motion } from 'framer-motion'
+import UsefulLinks from './UsefulLinks'
+
 import { PACKAGE_NAMES } from '../../constants'
 
 const Container = styled.div`
@@ -124,11 +126,6 @@ const Separator = styled.hr`
   border: 0;
 `
 
-const List = styled.ol`
-  padding-inline-start: 18px;
-  margin: 10px 0 0;
-`
-
 class UsefulContentSection extends Component {
   state = {
     isContentVisible: true
@@ -198,8 +195,6 @@ class UsefulContentSection extends Component {
       return null
     }
 
-    const hasMoreThanOneRelease = versions.length > 1
-
     return (
       <Container isContentVisible={isContentVisible}>
         <InnerContainer isContentVisible={isContentVisible}>
@@ -216,31 +211,11 @@ class UsefulContentSection extends Component {
           />
 
           <ContentContainer isContentVisible={isContentVisible}>
-            {versions.map(({ usefulContent, version }, key) => {
-              const changelog = this.getChangelog({ version })
+            <UsefulLinks versions={versions} />
 
-              const links = [...usefulContent.links, changelog]
+            <UpgradeSupportAlert />
 
-              return (
-                <Fragment key={key}>
-                  {key > 0 && <Separator />}
-
-                  {hasMoreThanOneRelease && (
-                    <h3>Release {changelog.version}</h3>
-                  )}
-
-                  <span>{usefulContent.description}</span>
-
-                  <List>
-                    {links.map(({ url, title }, key) => (
-                      <li key={`${url}${key}`}>
-                        <Link href={url}>{title}</Link>
-                      </li>
-                    ))}
-                  </List>
-                </Fragment>
-              )
-            })}
+            <Separator />
 
             <UpgradeSupportAlert />
 

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -187,13 +187,9 @@ class UsefulContentSection extends Component {
       toVersion
     })
 
-    const doesAnyVersionHaveUsefulContent = versions.some(
+    const doesAnyVersionHaveUsefulLinks = versions.some(
       ({ usefulContent }) => !!usefulContent
     )
-
-    if (!doesAnyVersionHaveUsefulContent) {
-      return null
-    }
 
     return (
       <Container isContentVisible={isContentVisible}>
@@ -211,7 +207,9 @@ class UsefulContentSection extends Component {
           />
 
           <ContentContainer isContentVisible={isContentVisible}>
-            <UsefulLinks versions={versions} />
+            {doesAnyVersionHaveUsefulLinks ? (
+              <UsefulLinks versions={versions} />
+            ) : null}
 
             <UpgradeSupportAlert />
 

--- a/src/components/common/UsefulLinks.js
+++ b/src/components/common/UsefulLinks.js
@@ -1,0 +1,95 @@
+import React, { Component, Fragment } from 'react'
+import styled from '@emotion/styled'
+import { getChangelogURL } from '../../utils'
+import { Link } from './Markdown'
+import { PACKAGE_NAMES } from '../../constants'
+
+const Separator = styled.hr`
+  margin: 15px 0;
+  background-color: #e1e4e8;
+  height: 0.25em;
+  border: 0;
+`
+
+const List = styled.ol`
+  padding-inline-start: 18px;
+  margin: 10px 0 0;
+`
+
+class UsefulLinks extends Component {
+  getChangelog = ({ version }) => {
+    const { packageName, toVersion } = this.props
+
+    if (
+      packageName === PACKAGE_NAMES.RNW ||
+      packageName === PACKAGE_NAMES.RNM
+    ) {
+      return {
+        title: `React Native ${
+          packageName === PACKAGE_NAMES.RNW ? 'Windows' : 'macOS'
+        } ${toVersion} changelog`,
+        url: getChangelogURL({
+          packageName,
+          version: toVersion
+        }),
+        version: toVersion
+      }
+    }
+
+    const versionWithoutEndingZero = version.slice(0, 4)
+
+    return {
+      title: `React Native ${versionWithoutEndingZero} changelog`,
+      url: getChangelogURL({
+        packageName,
+        version: versionWithoutEndingZero
+      }),
+      version: versionWithoutEndingZero
+    }
+  }
+
+  render() {
+    const { versions } = this.props
+
+    const doesAnyVersionHaveUsefulContent = versions.some(
+      ({ usefulContent }) => !!usefulContent
+    )
+
+    if (!doesAnyVersionHaveUsefulContent) {
+      return null
+    }
+
+    const hasMoreThanOneRelease = versions.length > 1
+
+    return (
+      <>
+        {versions.map(({ usefulContent, version }, key) => {
+          const changelog = this.getChangelog({ version })
+
+          const links = [...usefulContent.links, changelog]
+
+          return (
+            <Fragment key={key}>
+              {key > 0 && <Separator />}
+
+              {hasMoreThanOneRelease && <h3>Release {changelog.version}</h3>}
+
+              <span>{usefulContent.description}</span>
+
+              <List>
+                {links.map(({ url, title }, key) => (
+                  <li key={`${url}${key}`}>
+                    <Link href={url}>{title}</Link>
+                  </li>
+                ))}
+              </List>
+            </Fragment>
+          )
+        })}
+        <Separator />
+      </>
+    )
+  }
+}
+
+export default UsefulLinks


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Started from this [twitter thread](https://twitter.com/lbentosilva/status/1522457986077179911) with @lucasbento & @pvinis, I decided to add in the callout section the fact that dep-check is a thing and that should help you :)

Copy is still a WIP tbh, I'm going to ask @afoxman and @tido64 to give their 👍 (on top of Lucas' and Pavlos', ofc!)

While doing so I realised that I wanted to do a bit more 😇 so I did a bit of refactoring so that on all releases we show some information that are not strictly version-bound (see screenshots for more). This also sets the stage for extracting from the links part the changelog bit so that we can also always parse up the RN versions changelog to show in the callout... but I left that part for some future work (potentially some good first issue material?).

Let me know what you think! :)

## Test Plan

### Before/after for when there are no useful links
<img width="1751" alt="Screenshot 2022-05-06 at 12 46 02" src="https://user-images.githubusercontent.com/16104054/167125716-1cd7685b-0253-4cc3-a126-d5486e8ef4e5.png">


### Before/after for when there are useful links
<img width="1804" alt="Screenshot 2022-05-06 at 12 46 24" src="https://user-images.githubusercontent.com/16104054/167125725-20e52ef9-e5b1-4037-800e-6fd5dffb6308.png">


## What are the steps to reproduce?

Just run the website on the branch :)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
