### PR TITLE
feat: highlight bundled Hermes for version 0.69

### DIFF
--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -2,6 +2,7 @@ import { PACKAGE_NAMES } from '../constants'
 
 const versionsWithContent = {
   [PACKAGE_NAMES.RN]: [
+    '0.69',
     '0.68',
     '0.64',
     '0.62',

--- a/src/releases/react-native/0.69.js
+++ b/src/releases/react-native/0.69.js
@@ -1,0 +1,28 @@
+import React, { Fragment } from 'react'
+
+export default {
+  usefulContent: {
+    description:
+      'React Native 0.69 includes a bundled version of the Hermes engine',
+    links: [
+      {
+        title: 'See here to learn more about bundled Hermes',
+        url: 'https://reactnative.dev/architecture/bundled-hermes'
+      }
+    ]
+  },
+  comments: [
+    {
+      fileName: 'android/app/build.gradle',
+      lineNumber: '280',
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          These lines instruct Gradle to build hermes from source. For further
+          information on bundled Hermes, look
+          <a href="https://reactnative.dev/architecture/bundled-hermes">here</a>
+        </Fragment>
+      )
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

This PR adds a banner and some comments to point out the changes required by bundled Hermes in version 0.69.

## Test Plan

CI passes
