### PR TITLE
Clarify the message on `build.gradle` file for 0.69

### DIFF
--- a/src/releases/react-native/0.69.js
+++ b/src/releases/react-native/0.69.js
@@ -18,8 +18,8 @@ export default {
       lineChangeType: 'add',
       content: (
         <Fragment>
-          These lines instruct Gradle to build hermes from source. For further
-          information on bundled Hermes, look
+          These lines instruct Gradle to consume the bundled version of Hermes. For further
+          information on Bundled Hermes and how this mechanism works, look
           [here]("https://reactnative.dev/architecture/bundled-hermes").
         </Fragment>
       )


### PR DESCRIPTION
# Summary

Just a small clarification on top of @cipolleschi's  change as I believe that could have caused confusion.

## Test Plan

N/A