### PR TITLE
fix changelog links in useful content section

### DIFF
--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -209,7 +209,7 @@ class UsefulContentSection extends Component {
 
           <ContentContainer isContentVisible={isContentVisible}>
             {doesAnyVersionHaveUsefulLinks ? (
-              <UsefulLinks versions={versions} />
+              <UsefulLinks packageName={packageName} versions={versions} />
             ) : null}
 
             <DepCheckAlert />


### PR DESCRIPTION
# Summary

previously on a comparison page [like this one](https://react-native-community.github.io/upgrade-helper/?from=0.63.4&to=0.69.0), we were having an
issue, where the changelog link was not set. this was due to the package
name not being accessible for the "UsefulLinks" component.
this commit fixes this issue

## Test Plan

Since this is only a small change, please head to the link above, and try to click on the "React Native 0.69 changelog" link. This will guide you to the right changelog link.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] ~I added the documentation in `README.md` (if needed)~
