### PR TITLE
chore(CI): fix up CI to be compliant with requirements (Node 16+)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repository code
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
 
       - name: 🛠 Install dependencies
         uses: bahmutov/npm-install@v1
@@ -20,7 +20,7 @@ jobs:
         run: yarn build
 
       - name: 🚀 Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: gh-pages
           folder: build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: ⬆️ Upload output
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: ./**
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Restore output
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Restore output
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Restore output
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.sha }}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Just a cheeky bump to some actions and settings - mirroring what I've done here last week: https://github.com/react-native-community/rn-diff-purge/pull/66

Nothing should break, but just in case here are the actions:
* https://github.com/actions/upload-artifact/releases
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-node/releases
* https://github.com/bahmutov/npm-install/releases
* https://github.com/JamesIves/github-pages-deploy-action/releases

## Test Plan

Testing: CI is ✅
