### PR TITLE
0.72: Add guidance on new metro.config.js setup

### DIFF
--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -2,6 +2,7 @@ import { PACKAGE_NAMES } from '../constants'
 
 const versionsWithContent = {
   [PACKAGE_NAMES.RN]: [
+    '0.72',
     '0.69',
     '0.68',
     '0.64',

--- a/src/releases/react-native/0.72.js
+++ b/src/releases/react-native/0.72.js
@@ -1,0 +1,22 @@
+import React, { Fragment } from 'react'
+
+export default {
+  comments: [
+    {
+      fileName: 'metro.config.js',
+      lineNumber: 1,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          In React Native 0.72, we've changed the config loading setup for Metro
+          in React Native CLI. The base React Native Metro config is now
+          explicitly required and extended here in your project's Metro config
+          file, giving you full control over the final config. In addition, this
+          means that standalone Metro CLI commands, such as [`metro
+          get-dependencies`](https://facebook.github.io/metro/docs/cli/#get-dependencies-entryfile)
+          will work. We've also cleaned up the leftover defaults.
+        </Fragment>
+      ),
+    },
+  ],
+}


### PR DESCRIPTION
# Summary

Annotates `metro.config.js` in 0.72 to highlight user impact of https://github.com/facebook/react-native/pull/36502.

## Test Plan

![image](https://user-images.githubusercontent.com/2547783/230357495-68e69d9b-6cde-41de-96f5-2538ed9a854d.png)
