### PR TITLE
Fix crash when upgrading from 0.68.6 or lower to 0.72.0 or higher

### DIFF
--- a/src/components/common/UsefulLinks.js
+++ b/src/components/common/UsefulLinks.js
@@ -67,7 +67,7 @@ class UsefulLinks extends Component {
           if (!usefulContent) {
             return null
           }
-      
+
           const changelog = this.getChangelog({ version })
 
           const links = [...usefulContent.links, changelog]

--- a/src/components/common/UsefulLinks.js
+++ b/src/components/common/UsefulLinks.js
@@ -64,6 +64,10 @@ class UsefulLinks extends Component {
     return (
       <>
         {versions.map(({ usefulContent, version }, key) => {
+          if (!usefulContent) {
+            return null
+          }
+      
           const changelog = this.getChangelog({ version })
 
           const links = [...usefulContent.links, changelog]

--- a/src/releases/react-native/0.72.js
+++ b/src/releases/react-native/0.72.js
@@ -1,6 +1,15 @@
 import React, { Fragment } from 'react'
 
 export default {
+  usefulContent: {
+    description: 'React Native 0.72 includes a new metro config setup',
+    links: [
+      {
+        title: 'Show about the major changes on React Native 0.72.0-rc.1',
+        url: 'https://github.com/facebook/react-native/releases/tag/v0.72.0-rc.1',
+      },
+    ],
+  },
   comments: [
     {
       fileName: 'metro.config.js',


### PR DESCRIPTION
# Summary
1. Preventing crashes when version files contain empty usefulContent. 
2. update 0.72 file in releases folder.

## Test Plan
1. select current react-native versions below 0.68.6.
2. select upgrade 0.72.0 or higher version.
3. click 'Show me how to upgrade!' button.
4. web is crushed.
