### PR TITLE
Fix copy on Safari

### DIFF
--- a/src/components/common/CopyFileButton.js
+++ b/src/components/common/CopyFileButton.js
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 import { Button, Popover } from 'antd'
 import { getFileApiURL, replaceWithProvidedAppName } from '../../utils'
 import { CopyOutlined } from '@ant-design/icons'
-import copy from 'copy-to-clipboard'
 
 const popoverContentOpts = {
   default: 'Copy raw contents',
@@ -15,6 +14,29 @@ const CopyFileButton = styled(
     const [popoverContent, setPopoverContent] = useState(
       popoverContentOpts.default
     )
+
+    const fetchContent = () =>
+      fetch(getFileApiURL({ packageName, version, path }))
+        .then((response) => response.json())
+        .then((json) => window.atob(json.content))
+        .then((content) => replaceWithProvidedAppName(content, appName))
+
+    const copyContent = () => {
+      // From https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
+      if (typeof ClipboardItem && navigator.clipboard.write) {
+        const item = new ClipboardItem({
+          'text/plain': fetchContent().then(
+            (content) => new Blob([content], { type: 'text/plain' })
+          ),
+        })
+
+        return navigator.clipboard.write([item])
+      } else {
+        return fetchContent().then((content) =>
+          navigator.clipboard.writeText(content)
+        )
+      }
+    }
 
     if (!open) {
       return null
@@ -30,12 +52,9 @@ const CopyFileButton = styled(
             setPopoverContent(popoverContentOpts.default)
           }}
           onClick={() => {
-            fetch(getFileApiURL({ packageName, version, path }))
-              .then((response) => response.json())
-              .then((json) => window.atob(json.content))
-              .then((content) => replaceWithProvidedAppName(content, appName))
-              .then((content) => copy(content))
-              .then(() => setPopoverContent(popoverContentOpts.copied))
+            copyContent().then(() =>
+              setPopoverContent(popoverContentOpts.copied)
+            )
           }}
         />
       </Popover>


### PR DESCRIPTION
Following https://github.com/react-native-community/upgrade-helper/pull/355, [one of my follower](https://twitter.com/alihdjr/status/1643956095575048192) noticed that it doesn't work correctly on Safari.

<img width="1456" alt="Screenshot 2023-04-10 at 12 00 27" src="https://user-images.githubusercontent.com/1902323/230883641-0e4a27c6-337a-4aa1-b306-4f4da7795172.png">

This occurs because the copy to clipboard is not done immediately after user interaction, in a synchronous way (as we have to fetch the file content before).

This PR fixes that, following [this guide](https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/). Tested successfully on Chrome / Firefox / Safari. Support is IMHO [good enough](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API).