### PR TITLE
feat: Add changelog link

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -1,6 +1,6 @@
 import { PACKAGE_NAMES } from '../constants'
 import '../releases/__mocks__/index'
-import { getVersionsContentInDiff } from '../utils'
+import { getVersionsContentInDiff, getChangelogURL } from '../utils'
 
 describe('getVersionsContentInDiff', () => {
   it('returns the versions in the provided range', () => {
@@ -35,5 +35,33 @@ describe('getVersionsContentInDiff', () => {
     })
 
     expect(versions).toEqual([{ version: '0.59' }, { version: '0.58' }])
+  })
+})
+
+describe('getChangelogURL', () => {
+  const { RN, RNM, RNW } = PACKAGE_NAMES
+  test.each([
+    [
+      RN,
+      '0.71.7',
+      'https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0717',
+    ],
+    [
+      RN,
+      '0.71.6',
+      'https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0716',
+    ],
+    [
+      RNM,
+      '0.71.5',
+      'https://github.com/microsoft/react-native-macos/releases/tag/v0.71.5',
+    ],
+    [
+      RNW,
+      '0.71.4',
+      'https://github.com/microsoft/react-native-windows/releases/tag/react-native-windows_v0.71.4',
+    ],
+  ])('getChangelogURL("%s", "%s") -> %s', (packageName, version, url) => {
+    expect(getChangelogURL({ packageName, version })).toEqual(url)
   })
 })

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -4,7 +4,7 @@ import { Alert } from 'antd'
 import { motion, AnimatePresence, AnimateSharedLayout } from 'framer-motion'
 import { withChangeSelect } from 'react-diff-view'
 import 'react-diff-view/style/index.css'
-import { getTransitionDuration } from '../../utils'
+import { getTransitionDuration, getChangelogURL } from '../../utils'
 import DiffSection from './Diff/DiffSection'
 import DiffLoading from './Diff/DiffLoading'
 import UsefulContentSection from './UsefulContentSection'
@@ -24,6 +24,11 @@ const TopContainer = styled.div`
   margin-top: 16px;
   flex-direction: row;
   justify-content: flex-end;
+`
+
+const Link = styled.a`
+  padding: 4px 15px;
+  color: #1677ff;
 `
 
 const getDiffKey = ({ oldRevision, newRevision }) =>
@@ -127,6 +132,16 @@ const DiffViewer = ({
 
   const [, jumpToAnchorOnce] = useReducer(jumpToAnchor, false)
 
+  let changelog
+  if (!toVersion.includes('-rc')) {
+    const href = getChangelogURL({ packageName, version: toVersion })
+    changelog = (
+      <Link href={href} target="_blank" rel="noreferrer">
+        changelog
+      </Link>
+    )
+  }
+
   useEffect(() => {
     if (!isDone) {
       resetCompletedDiffs()
@@ -175,6 +190,8 @@ const DiffViewer = ({
           />
 
           <TopContainer>
+            {changelog}
+
             <BinaryDownload
               diff={diff}
               fromVersion={fromVersion}

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,7 +100,7 @@ export const getChangelogURL = ({ version, packageName }) => {
     return `${RN_CHANGELOG_URLS[packageName]}v${version}`
   }
 
-  return `${RN_CHANGELOG_URLS[packageName]}#v${version.replace('.', '')}0`
+  return `${RN_CHANGELOG_URLS[packageName]}#v${version.replaceAll('.', '')}`
 }
 
 // If the browser is headless (running puppeteer) then it doesn't have any duration


### PR DESCRIPTION
Let users open a tab with the CHANGELOG, and just to the target version.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Provides anchor links to the CHANGELOG for the target version.

![CleanShot 2023-04-26 at 16 00 17@2x](https://user-images.githubusercontent.com/49578/234618803-56fcf455-e6f6-4a3c-8f5e-dfe658078dda.png)

This is more useful or vanilla React Native.  For windows and macos it link to their release tags.  Caveat: because these projects aren't always synced to the latest React Native releases, some of these links may not exist.


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

Added some unit tests and tested on my device.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
