### PR TITLE
Fix encoding issues when using Copy button

### DIFF
--- a/src/components/common/CopyFileButton.js
+++ b/src/components/common/CopyFileButton.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import { Button, Popover } from 'antd'
-import { getFileApiURL, replaceWithProvidedAppName } from '../../utils'
+import { getBinaryFileURL, replaceWithProvidedAppName } from '../../utils'
 import { CopyOutlined } from '@ant-design/icons'
 
 const popoverContentOpts = {
@@ -16,9 +16,8 @@ const CopyFileButton = styled(
     )
 
     const fetchContent = () =>
-      fetch(getFileApiURL({ packageName, version, path }))
-        .then((response) => response.json())
-        .then((json) => window.atob(json.content))
+      fetch(getBinaryFileURL({ packageName, version, path }))
+        .then((response) => response.text())
         .then((content) => replaceWithProvidedAppName(content, appName))
 
     const copyContent = () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,17 +44,9 @@ const getBranch = ({ packageName, language, version }) =>
 export const getBinaryFileURL = ({ packageName, language, version, path }) => {
   const branch = getBranch({ packageName, language, version })
 
-  return `https://github.com/${getRNDiffRepository({
+  return `https://raw.githubusercontent.com/${getRNDiffRepository({
     packageName,
-  })}/raw/release/${branch}/${path}`
-}
-
-export const getFileApiURL = ({ packageName, language, version, path }) => {
-  const branch = getBranch({ packageName, language, version })
-
-  return `https://api.github.com/repos/${getRNDiffRepository({
-    packageName,
-  })}/contents/${path}?ref=${encodeURIComponent(`release/${branch}`)}`
+  })}/release/${branch}/${path}`
 }
 
 export const removeAppPathPrefix = (path, appName) =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

This PR fixes an issue with the Copy button, where unicode characters were not correctly encoded. This is because the current implementation uses the GitHub API to fetch and decode file contents in base64 format. This results in characters such as the copyright symbol being copied as `Â©`. This is particularly noticeable in `android/gradlew`, which also uses `«` and `»` in its comments, ending up as `Â«` and `Â»`. This is a common issue when using base64, described as [The Unicode Problem on MDN](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem).

One solution to this issue would be to use [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder), but the code can get a bit hard to read because the base64 first needs to be converted to a binary array. I decided to instead fetch the file directly and use its contents, as it avoids any other potential unforeseen base64 issues, as well as slightly reducing the request size (no API overhead).

To make this fix work, I had to change the base url used by `getBinaryFileURL` to `https://raw.githubusercontent.com/`. Using `https://github.com/.../raw` caused CORS failures, which were resolved by changing to the base url. This change also makes the function consistent with the existing `getReleasesFileURL` and `getDiffURL` functions, which already use `https://raw.githubusercontent.com/`.

## Test Plan

I tested this in Chrome, Safari and Firefox on MacOS. All of these browsers previously copied unicode text incorrectly. With the changes in this PR, they now correctly copy unicode text.

I also tested that downloading and viewing files still works, as I changed the url for `getBinaryFileURL` to resolve CORS issues.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## What are the steps to reproduce?

To see the issue in the current version, try [comparing 0.71.12 to 0.72.1](https://react-native-community.github.io/upgrade-helper/?from=0.71.12&to=0.72.1). Go to `android/gradlew` and press the Copy button. You should see that the copyright symbol incorrectly has an `Â` in front of it.

Doing the same copy on this PR's branch should copy the contents correctly, without this extra `Â`.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
