### PR TITLE
Add ability to specify custom app package for Android code diffs e.g. org.myorg

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -1,6 +1,10 @@
 import { PACKAGE_NAMES } from '../constants'
 import '../releases/__mocks__/index'
-import { getVersionsContentInDiff, getChangelogURL } from '../utils'
+import {
+  getVersionsContentInDiff,
+  replaceAppDetails,
+  getChangelogURL,
+} from '../utils'
 
 describe('getVersionsContentInDiff', () => {
   it('returns the versions in the provided range', () => {
@@ -64,4 +68,67 @@ describe('getChangelogURL', () => {
   ])('getChangelogURL("%s", "%s") -> %s', (packageName, version, url) => {
     expect(getChangelogURL({ packageName, version })).toEqual(url)
   })
+})
+
+describe('replaceAppDetails ', () => {
+  test.each([
+    // Don't change anything if no app name or package is passed.
+    [
+      'RnDiffApp/ios/RnDiffApp/main.m',
+      '',
+      '',
+      'RnDiffApp/ios/RnDiffApp/main.m',
+    ],
+    [
+      'android/app/src/debug/java/com/rndiffapp/ReactNativeFlipper.java',
+      '',
+      '',
+      'android/app/src/debug/java/com/rndiffapp/ReactNativeFlipper.java',
+    ],
+    [
+      'location = "group:RnDiffApp.xcodeproj">',
+      '',
+      '',
+      'location = "group:RnDiffApp.xcodeproj">',
+    ],
+    // Update Java file path with correct app name and package.
+    [
+      'android/app/src/debug/java/com/rndiffapp/ReactNativeFlipper.java',
+      'SuperApp',
+      'au.org.mycorp',
+      'android/app/src/debug/java/au/org/mycorp/superapp/ReactNativeFlipper.java',
+    ],
+    // Update the app details in file contents.
+    [
+      'location = "group:RnDiffApp.xcodeproj">',
+      'MyFancyApp',
+      '',
+      'location = "group:MyFancyApp.xcodeproj">',
+    ],
+    [
+      'applicationId "com.rndiffapp"',
+      'ACoolApp',
+      'net.foobar',
+      'applicationId "net.foobar.acoolapp"',
+    ],
+    // Don't accidentally pick up other instances of "com" such as in domain
+    // names, or android or facebook packages.
+    [
+      'apply plugin: "com.android.application"',
+      'ACoolApp',
+      'net.foobar',
+      'apply plugin: "com.android.application"',
+    ],
+    [
+      '* https://github.com/facebook/react-native',
+      'ACoolApp',
+      'net.foobar',
+      '* https://github.com/facebook/react-native',
+    ],
+  ])(
+    'replaceAppDetails("%s", "%s", "%s") -> %s',
+    (path, appName, appPackage, newPath) => {
+      expect(replaceAppDetails(path, appName, appPackage)).toEqual(newPath)
+    }
+  )
 })

--- a/src/components/common/CopyFileButton.js
+++ b/src/components/common/CopyFileButton.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import { Button, Popover } from 'antd'
-import { getBinaryFileURL, replaceWithProvidedAppName } from '../../utils'
+import { getBinaryFileURL, replaceAppDetails } from '../../utils'
 import { CopyOutlined } from '@ant-design/icons'
 
 const popoverContentOpts = {
@@ -10,7 +10,7 @@ const popoverContentOpts = {
 }
 
 const CopyFileButton = styled(
-  ({ open, version, path, packageName, appName, ...props }) => {
+  ({ open, version, path, packageName, appName, appPackage, ...props }) => {
     const [popoverContent, setPopoverContent] = useState(
       popoverContentOpts.default
     )
@@ -18,7 +18,7 @@ const CopyFileButton = styled(
     const fetchContent = () =>
       fetch(getBinaryFileURL({ packageName, version, path }))
         .then((response) => response.text())
-        .then((content) => replaceWithProvidedAppName(content, appName))
+        .then((content) => replaceAppDetails(content, appName, appPackage))
 
     const copyContent = () => {
       // From https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/

--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -9,7 +9,7 @@ import {
 } from 'react-diff-view'
 import DiffHeader from './DiffHeader'
 import { getComments } from './DiffComment'
-import { replaceWithProvidedAppName } from '../../../utils'
+import { replaceAppDetails } from '../../../utils'
 
 const copyPathPopoverContentOpts = {
   default: 'Click to copy file path',
@@ -102,6 +102,7 @@ const Diff = ({
   setAllCollapsed,
   diffViewStyle,
   appName,
+  appPackage,
 }) => {
   const [isDiffCollapsed, setIsDiffCollapsed] = useState(
     isDiffCollapsedByDefault({ type, hunks })
@@ -123,7 +124,8 @@ const Diff = ({
 
   const getHunksWithAppName = useCallback(
     (originalHunks) => {
-      if (!appName) {
+      if (!appName && !appPackage) {
+        // No patching of rn-diff-purge output required.
         return originalHunks
       }
 
@@ -131,12 +133,12 @@ const Diff = ({
         ...hunk,
         changes: hunk.changes.map((change) => ({
           ...change,
-          content: replaceWithProvidedAppName(change.content, appName),
+          content: replaceAppDetails(change.content, appName, appPackage),
         })),
-        content: replaceWithProvidedAppName(hunk.content, appName),
+        content: replaceAppDetails(hunk.content, appName, appPackage),
       }))
     },
-    [appName]
+    [appName, appPackage]
   )
 
   if (areAllCollapsed !== undefined && areAllCollapsed !== isDiffCollapsed) {
@@ -178,6 +180,7 @@ const Diff = ({
         resetCopyPathPopoverContent={handleResetCopyPathPopoverContent}
         onCompleteDiff={onCompleteDiff}
         appName={appName}
+        appPackage={appPackage}
         diffComments={diffComments}
         packageName={packageName}
       />
@@ -226,6 +229,7 @@ const arePropsEqual = (prevProps, nextProps) =>
   prevProps.isDiffCompleted === nextProps.isDiffCompleted &&
   prevProps.areAllCollapsed === nextProps.areAllCollapsed &&
   prevProps.diffViewStyle === nextProps.diffViewStyle &&
-  prevProps.appName === nextProps.appName
+  prevProps.appName === nextProps.appName &&
+  prevProps.appPackage === nextProps.appPackage
 
 export default React.memo(Diff, arePropsEqual)

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -243,11 +243,17 @@ const DiffHeader = ({
   copyPathPopoverContent,
   resetCopyPathPopoverContent,
   appName,
+  appPackage,
   diffComments,
   packageName,
   ...props
 }) => {
-  const sanitizedFilePaths = getFilePathsToShow({ oldPath, newPath, appName })
+  const sanitizedFilePaths = getFilePathsToShow({
+    oldPath,
+    newPath,
+    appName,
+    appPackage,
+  })
 
   const id = React.useMemo(
     () => generatePathId(oldPath, newPath),
@@ -308,6 +314,7 @@ const DiffHeader = ({
           path={newPath}
           packageName={packageName}
           appName={appName}
+          appPackage={appPackage}
         />
         <DownloadFileButton
           open={!hasDiff && type !== 'delete'}

--- a/src/components/common/Diff/DiffSection.js
+++ b/src/components/common/Diff/DiffSection.js
@@ -25,6 +25,7 @@ const DiffSection = ({
   onToggleChangeSelection,
   diffViewStyle,
   appName,
+  appPackage,
   doneTitleRef,
 }) => {
   const [areAllCollapsed, setAllCollapsed] = useState(undefined)
@@ -86,6 +87,7 @@ const DiffSection = ({
             areAllCollapsed={areAllCollapsed}
             setAllCollapsed={setAllCollapsed}
             appName={appName}
+            appPackage={appPackage}
           />
         )
       })}

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -59,6 +59,7 @@ const DiffViewer = ({
   selectedChanges,
   onToggleChangeSelection,
   appName,
+  appPackage,
 }) => {
   const { isLoading, isDone, diff } = useFetchDiff({
     shouldShowDiff,
@@ -197,6 +198,7 @@ const DiffViewer = ({
               fromVersion={fromVersion}
               toVersion={toVersion}
               appName={appName}
+              appPackage={appPackage}
               packageName={packageName}
             />
 
@@ -212,6 +214,7 @@ const DiffViewer = ({
             isDoneSection={false}
             diffViewStyle={diffViewStyle}
             appName={appName}
+            appPackage={appPackage}
           />
 
           {renderUpgradeDoneMessage({ diff, completedDiffs })}
@@ -222,6 +225,7 @@ const DiffViewer = ({
             isDoneSection={true}
             title="Done"
             appName={appName}
+            appPackage={appPackage}
             doneTitleRef={doneTitleRef}
           />
         </motion.div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 export const DEFAULT_APP_NAME = 'RnDiffApp'
+export const DEFAULT_APP_PACKAGE = 'com'
 
 export const PACKAGE_NAMES = {
   RN: 'react-native',


### PR DESCRIPTION
# Summary

Adding functionality to let users specify their own package name (for Android Java builds) as well as the app name.

Simplified form field state while keeping UI snappy (making use of useDeferredValue). Preferred replaceAll with plain old strings rather than RegExps. Latter probably overkill and harder to read when constructing more elaborate search strings for package substitution code.

Resolves issues #339 and #366.

## Test Plan

Added some unit tests adjacent to the main function being changed.

## Checklist

- [X] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)

Update to readme not required.