### PR TITLE
Fix app name / package replacement

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -96,7 +96,7 @@ describe('replaceAppDetails ', () => {
       'android/app/src/debug/java/com/rndiffapp/ReactNativeFlipper.java',
       'SuperApp',
       'au.org.mycorp',
-      'android/app/src/debug/java/au/org/mycorp/superapp/ReactNativeFlipper.java',
+      'android/app/src/debug/java/au/org/mycorp/ReactNativeFlipper.java',
     ],
     // Update the app details in file contents.
     [
@@ -109,7 +109,7 @@ describe('replaceAppDetails ', () => {
       'applicationId "com.rndiffapp"',
       'ACoolApp',
       'net.foobar',
-      'applicationId "net.foobar.acoolapp"',
+      'applicationId "net.foobar"',
     ],
     // Don't accidentally pick up other instances of "com" such as in domain
     // names, or android or facebook packages.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 export const DEFAULT_APP_NAME = 'RnDiffApp'
-export const DEFAULT_APP_PACKAGE = 'com'
+export const DEFAULT_APP_PACKAGE = 'com.rndiffapp'
 
 export const PACKAGE_NAMES = {
   RN: 'react-native',

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,38 +54,23 @@ export const removeAppPathPrefix = (path, appName) =>
   path.replace(new RegExp(`${appName || DEFAULT_APP_NAME}/`), '')
 
 /**
- * Replaces DEFAULT_APP_NAME and DEFAULT_APP_PACKAGE in str with custom
+ * Replaces DEFAULT_APP_PACKAGE and DEFAULT_APP_NAME in str with custom
  * values if provided.
  * str could be a path, or content from a text file.
  */
 export const replaceAppDetails = (str, appName, appPackage) => {
-  let newStr = str
-  if (appName) {
-    newStr = newStr
-      .replaceAll(DEFAULT_APP_NAME, appName)
-      .replaceAll(DEFAULT_APP_NAME.toLowerCase(), appName.toLowerCase())
-  }
+  const appNameOrFallback = appName || DEFAULT_APP_NAME
+  const appPackageOrFallback =
+    appPackage || `com.${appNameOrFallback.toLowerCase()}`
 
-  if (appPackage) {
-    // TODO should we use node path.sep instead of hardcoding /?
-    // com.foo.bar -> com/foo/bar
-    const appPackageAsPath = appPackage.replaceAll('.', '/')
-
-    // Only replace if DEFAULT_APP_PACKAGE a.k.a. "com" is followed by lower
-    // case appName. Otherwise we unwittingly pick up "com.android..." or
-    // "https://github.com/facebook..."
-    newStr = newStr
-      .replaceAll(
-        `${DEFAULT_APP_PACKAGE}/${appName.toLowerCase()}`,
-        `${appPackageAsPath}/${appName.toLowerCase()}`
-      )
-      .replaceAll(
-        `${DEFAULT_APP_PACKAGE}.${appName.toLowerCase()}`,
-        `${appPackage}.${appName.toLowerCase()}`
-      )
-  }
-
-  return newStr
+  return str
+    .replaceAll(DEFAULT_APP_PACKAGE, appPackageOrFallback)
+    .replaceAll(
+      DEFAULT_APP_PACKAGE.replaceAll('.', '/'),
+      appPackageOrFallback.replaceAll('.', '/')
+    )
+    .replaceAll(DEFAULT_APP_NAME, appNameOrFallback)
+    .replaceAll(DEFAULT_APP_NAME.toLowerCase(), appNameOrFallback.toLowerCase())
 }
 
 export const getVersionsContentInDiff = ({


### PR DESCRIPTION
# Summary

Currently, app name / package replacement is kinda broken.

## What are the steps to reproduce?

<img width="1169" alt="Screenshot 2023-09-08 at 19 03 25" src="https://github.com/react-native-community/upgrade-helper/assets/1902323/700171ac-9d87-459c-b722-78fac4a1dfbe">

Let's say we have this scenario: My app name is `Swan`, my app package is `io.swan.id`. With this config, on the current version of the upgrade helper, you will notice that the app name is append to the app package, making it `io.swan.id.swan`

This is visible in paths or if you copy file raw content:

<img width="1456" alt="Screenshot 2023-09-08 at 19 42 51" src="https://github.com/react-native-community/upgrade-helper/assets/1902323/5964086b-5689-4014-a396-c4c7b512ce10">

<img width="480" alt="Screenshot 2023-09-08 at 19 45 22" src="https://github.com/react-native-community/upgrade-helper/assets/1902323/2c68b7fa-4b57-4b41-a97b-a862349283ae">

---

This PR fixes all of this. It also:
- Fixes the app package placeholder
- Fixes the tests (which are actually expecting an incorrect result, as we can also see that the app name is appended)
- Continues to use `com.${appName.toLowercase()}` if app name is set, but app package is not

## Test Plan

Check both files content and paths with:
- no app name + no app package
- an app name but no app package
- an app name and an app package

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
