### PR TITLE
Implement Dark Mode Toggle

### DIFF
--- a/src/components/common/BinaryDownload.js
+++ b/src/components/common/BinaryDownload.js
@@ -12,15 +12,15 @@ const BinaryRow = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: ${({ index }) => (index % 2 === 0 ? '#fafbfc' : '#ffffff')};
-  color: #24292e;
+  background-color: ${({ index, theme }) =>
+    index % 2 === 0 ? theme.rowEven : theme.rowOdd};
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,
     monospace;
   font-size: 12px;
   width: 500px;
   max-width: 500px;
   padding: 10px 15px;
-  border-bottom: 1px solid #e1e4e8;
+  border-bottom: 1px solid ${({ theme }) => theme.border};
 `
 
 const Popover = styled(({ className, ...props }) => (
@@ -28,7 +28,6 @@ const Popover = styled(({ className, ...props }) => (
 ))`
   .ant-popover-inner-content {
     padding: 0;
-    background: red;
   }
 `
 

--- a/src/components/common/CompletedFilesCounter.js
+++ b/src/components/common/CompletedFilesCounter.js
@@ -56,11 +56,11 @@ const CompletedFilesCounter = styled(
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background: #d5eafd;
+  background: ${({ theme }) => theme.popover.background};
   padding: 10px;
-  border: 1px solid #1890ff;
+  border: 1px solid ${({ theme }) => theme.popover.border};
   border-radius: 20px;
-  color: #7dadda;
+  color: ${({ theme }) => theme.popover.text};
   transform: ${({ completed }) =>
     completed ? 'translateY(0px)' : 'translateY(70px)'};
   display: flex;
@@ -76,7 +76,7 @@ const CompletedFilesCounter = styled(
     `}
 
   .completedAmount {
-    color: #1890ff;
+    color: ${({ theme }) => theme.popover.border};
   }
 `
 

--- a/src/components/common/DarkModeButton.js
+++ b/src/components/common/DarkModeButton.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Button as AntdButton, Tooltip } from 'antd'
+import styled from '@emotion/styled'
+
+const Button = styled(AntdButton)`
+  width: 32px;
+  padding: 0;
+`
+
+const DarkModeButton = ({ isDarkMode, ...props }) => {
+  return (
+    <Tooltip placement="bottomLeft" title="Toggle Light/Dark Mode">
+      <Button {...props}>{isDarkMode ? '🌙' : '☀️'}</Button>
+    </Tooltip>
+  )
+}
+
+export { DarkModeButton }

--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -21,17 +21,17 @@ const Container = styled.div`
   border-radius: 3px;
   margin-bottom: 16px;
   margin-top: 16px;
+  color: ${({ theme }) => theme.text};
 `
 
 const More = styled.div`
-  background-color: #f1f8ff;
   margin-left: 30px;
   padding-left: 4px;
-  color: '#1b1f23b3';
 `
 
 const Decoration = styled(DiffDecoration)`
-  background-color: #dbedff;
+  background-color: ${({ theme }) => theme.diff.decorationContentBackground};
+  color: ${({ theme }) => theme.diff.decorationContent};
 `
 
 const DiffView = styled(RDiff)`
@@ -44,31 +44,19 @@ const DiffView = styled(RDiff)`
       monospace;
   }
 
-  td.diff-gutter {
-    color: rgba(27, 31, 35, 0.3);
-    padding: 0;
-    text-align: center;
-    font-size: 12px;
-    cursor: auto;
-  }
-
   td.diff-gutter .diff-line-normal {
-    background-color: ${({ theme }) => theme.lightGreenBackground};
+    background-color: ${({ theme }) => theme.gutterInsertBackground};
     border-color: ${({ theme }) => theme.greenBorder};
   }
 
   td.diff-gutter:hover {
     cursor: pointer;
-    color: rgba(27, 31, 35, 0.6);
+    color: ${({ theme }) => theme.textHover};
   }
 
   td.diff-code {
     font-size: 12px;
-    color: #24292e;
-  }
-
-  td.diff-code-insert .diff-code-edit {
-    background-color: ${({ theme }) => theme.darkGreenBackground};
+    color: ${({ theme }) => theme.text};
   }
 
   td.diff-gutter-omit:before {
@@ -78,6 +66,79 @@ const DiffView = styled(RDiff)`
 
   td.diff-widget-content {
     padding: 0;
+  }
+
+  // From diff global
+  .diff {
+    background-color: ${({ theme }) => theme.diff.backgroundColor};
+    color: ${({ theme }) => theme.diff.text};
+    tab-size: 4;
+    hyphens: none;
+  }
+
+  .diff::selection {
+    background-color: ${({ theme }) => theme.diff.selectionMackground};
+  }
+
+  .diff-decoration {
+    line-height: 2;
+    font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier,
+      monospace;
+    background-color: ${({ theme }) => theme.diff.decorationBackground};
+  }
+
+  .diff-decoration-content {
+    padding-left: 0.5em;
+    background-color: ${({ theme }) => theme.diff.contentBackground};
+    color: ${({ theme }) => theme.diff.decorationContent};
+  }
+
+  .diff-gutter {
+    padding: 0;
+    text-align: center;
+    font-size: 12px;
+    cursor: auto;
+  }
+
+  .diff-gutter-insert {
+    background-color: ${({ theme }) => theme.diff.gutterInsertBackground};
+  }
+
+  .diff-gutter-delete {
+    background-color: ${({ theme }) => theme.diff.gutterDeleteBackground};
+  }
+
+  .diff-gutter-selected {
+    background-color: ${({ theme }) => theme.diff.gutterSelectedBackground};
+  }
+
+  .diff-code-insert {
+    background-color: ${({ theme }) => theme.diff.codeInsertBackground};
+  }
+
+  .diff-code-edit {
+    color: inherit;
+  }
+
+  .diff-code-insert .diff-code-edit {
+    background-color: ${({ theme }) => theme.diff.codeInsertEditBackground};
+  }
+
+  .diff-code-delete {
+    background-color: ${({ theme }) => theme.diff.codeDeleteBackground};
+  }
+
+  .diff-code-delete .diff-code-edit {
+    background-color: ${({ theme }) => theme.diff.codeDeleteEditBackground};
+  }
+
+  .diff-code-selected {
+    background-color: ${({ theme }) => theme.diff.codeSelectedBackground};
+  }
+
+  .diff-decoration-gutter {
+    background-color: ${({ theme }) => theme.diff.decorationGutterBackground};
+    color: ${({ theme }) => theme.diff.decorationGutter};
   }
 `
 

--- a/src/components/common/Diff/Diff.js
+++ b/src/components/common/Diff/Diff.js
@@ -17,7 +17,7 @@ const copyPathPopoverContentOpts = {
 }
 
 const Container = styled.div`
-  border: 1px solid #e8e8e8;
+  border: 1px solid ${({ theme }) => theme.border};
   border-radius: 3px;
   margin-bottom: 16px;
   margin-top: 16px;
@@ -53,8 +53,8 @@ const DiffView = styled(RDiff)`
   }
 
   td.diff-gutter .diff-line-normal {
-    background-color: #cdffd8;
-    border-color: #bef5cb;
+    background-color: ${({ theme }) => theme.lightGreenBackground};
+    border-color: ${({ theme }) => theme.greenBorder};
   }
 
   td.diff-gutter:hover {
@@ -68,7 +68,7 @@ const DiffView = styled(RDiff)`
   }
 
   td.diff-code-insert .diff-code-edit {
-    background-color: #acf2bd;
+    background-color: ${({ theme }) => theme.darkGreenBackground};
   }
 
   td.diff-gutter-omit:before {

--- a/src/components/common/Diff/DiffComment.js
+++ b/src/components/common/Diff/DiffComment.js
@@ -4,37 +4,40 @@ import { motion } from 'framer-motion'
 import { removeAppPathPrefix, getVersionsContentInDiff } from '../../../utils'
 import Markdown from '../Markdown'
 
-const lineColors = {
-  add: '#d6fedb',
-  delete: '#fdeff0',
-  neutral: '#ffffff',
-}
-
-const Container = styled(({ isCommentOpen, children, ...props }) => (
-  <motion.div
-    {...props}
-    variants={{
-      open: {
-        height: 'auto',
-      },
-      hidden: { height: 10 },
-    }}
-    initial={isCommentOpen ? 'open' : 'hidden'}
-    animate={isCommentOpen ? 'open' : 'hidden'}
-    transition={{
-      duration: 0.5,
-    }}
-    inherit={false}
-  >
-    <div children={children} />
-  </motion.div>
-))`
+const Container = styled(({ isCommentOpen, children, ...props }) => {
+  return (
+    <motion.div
+      {...props}
+      variants={{
+        open: {
+          height: 'auto',
+        },
+        hidden: { height: 10 },
+      }}
+      initial={isCommentOpen ? 'open' : 'hidden'}
+      animate={isCommentOpen ? 'open' : 'hidden'}
+      transition={{
+        duration: 0.5,
+      }}
+      inherit={false}
+    >
+      <div children={children} />
+    </motion.div>
+  )
+})`
   overflow: hidden;
 
   & > div {
     display: flex;
     flex-direction: row;
-    background-color: ${({ lineChangeType }) => lineColors[lineChangeType]};
+    background-color: ${({ lineChangeType, theme }) => {
+      const colorMap = {
+        add: theme.diff.codeInsertBackground,
+        delete: theme.diff.codeDeleteBackground,
+      }
+
+      return colorMap[lineChangeType] || theme.background
+    }};
     cursor: pointer;
   }
 `
@@ -43,8 +46,8 @@ const ContentContainer = styled.div`
   flex: 1;
   position: relative;
   padding: 16px;
-  color: #000;
-  background-color: #fffbe6;
+  color: ${({ theme }) => theme.text};
+  background-color: ${({ theme }) => theme.yellowBackground};}
   user-select: none;
 `
 
@@ -67,7 +70,7 @@ const ShowButton = styled(({ isCommentOpen, ...props }) => (
     }}
   />
 ))`
-  background-color: #ffe58f;
+  background-color: ${({ theme }) => theme.yellowBorder};
   margin-left: 20px;
   width: 10px;
   cursor: pointer;

--- a/src/components/common/Diff/DiffCommentReminder.js
+++ b/src/components/common/Diff/DiffCommentReminder.js
@@ -32,11 +32,11 @@ const DiffCommentReminder = styled(
   }
 )`
   display: inline;
-  background-color: #fffbe6;
+  background-color: ${({ theme }) => theme.yellowBackground};
   padding: 5px;
   border-radius: 3px;
   margin-left: 10px;
-  border: 1px solid #ffe58f;
+  border: 1px solid ${({ theme }) => theme.yellowBorder};
 
   & > .icon {
     margin-right: 6px;

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -122,8 +122,8 @@ const CompleteDiffButton = styled(({ open, onClick, ...props }) =>
   &,
   &:hover,
   &:focus {
-    color: ${({ isDiffCompleted }) =>
-      isDiffCompleted ? '#52c41a' : '#24292e'};
+    color: ${({ isDiffCompleted, theme }) =>
+      isDiffCompleted ? '#52c41a' : theme.text};
   }
 `
 

--- a/src/components/common/Diff/DiffHeader.js
+++ b/src/components/common/Diff/DiffHeader.js
@@ -26,10 +26,10 @@ const Wrapper = styled.div`
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,
     monospace;
   font-size: 12px;
-  color: #24292e;
+  color: ${({ theme }) => theme.text};
   line-height: 32px;
-  background-color: #fafbfc;
-  border-bottom: 1px solid #e1e4e8;
+  background-color: ${({ theme }) => theme.background};
+  border-bottom: 1px solid ${({ theme }) => theme.border};
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
   padding: 5px 10px;
@@ -212,7 +212,7 @@ const CollapseClickableArea = styled.div`
 const CollapseDiffButton = styled(({ open, isDiffCollapsed, ...props }) =>
   open ? <Button {...props} type="link" icon={<DownOutlined />} /> : null
 )`
-  color: #24292e;
+  color: ${({ theme }) => theme.text};
   margin-right: 2px;
   font-size: 10px;
   transform: ${({ isDiffCollapsed }) =>
@@ -223,7 +223,7 @@ const CollapseDiffButton = styled(({ open, isDiffCollapsed, ...props }) =>
   height: auto;
   &:hover,
   &:focus {
-    color: #24292e;
+    color: ${({ theme }) => theme.text};
   }
 `
 

--- a/src/components/common/Diff/DiffLoading.js
+++ b/src/components/common/Diff/DiffLoading.js
@@ -3,34 +3,43 @@ import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import ContentLoader from 'react-content-loader'
 import { getTransitionDuration } from '../../../utils'
+import { useTheme } from '@emotion/react'
 
-const TitleLoader = () => (
-  <ContentLoader
-    speed={1}
-    backgroundColor="#eee"
-    foregroundColor="#e6e6e6"
-    viewBox="0 0 400 100"
-  >
-    <rect width="250" height="6" rx="1.5" />
-  </ContentLoader>
-)
+const TitleLoader = () => {
+  const theme = useTheme()
 
-const DiffLoader = () => (
-  <ContentLoader
-    speed={1}
-    backgroundColor="#eee"
-    foregroundColor="#e6e6e6"
-    viewBox="0 0 400 100"
-  >
-    <rect x="0" y="10" width="47%" height="6" rx="1.5" />
-    <rect x="200" y="10" width="41%" height="6" rx="1.5" />
-    <rect x="0" y="18" width="43%" height="6" rx="1.5" />
-    <rect x="200" y="34" width="40%" height="6" rx="1.5" />
-    <rect x="200" y="42" width="45%" height="6" rx="1.5" />
-    <rect x="0" y="42" width="40%" height="6" rx="1.5" />
-    <rect x="0" y="50" width="44%" height="6" rx="1.5" />
-  </ContentLoader>
-)
+  return (
+    <ContentLoader
+      speed={1}
+      backgroundColor={theme.rowOdd}
+      foregroundColor={theme.rowEven}
+      viewBox="0 0 400 100"
+    >
+      <rect width="250" height="6" rx="1.5" />
+    </ContentLoader>
+  )
+}
+
+const DiffLoader = () => {
+  const theme = useTheme()
+
+  return (
+    <ContentLoader
+      speed={1}
+      backgroundColor={theme.rowOdd}
+      foregroundColor={theme.rowEven}
+      viewBox="0 0 400 100"
+    >
+      <rect x="0" y="10" width="47%" height="6" rx="1.5" />
+      <rect x="200" y="10" width="41%" height="6" rx="1.5" />
+      <rect x="0" y="18" width="43%" height="6" rx="1.5" />
+      <rect x="200" y="34" width="40%" height="6" rx="1.5" />
+      <rect x="200" y="42" width="45%" height="6" rx="1.5" />
+      <rect x="0" y="42" width="40%" height="6" rx="1.5" />
+      <rect x="0" y="50" width="44%" height="6" rx="1.5" />
+    </ContentLoader>
+  )
+}
 
 const Container = styled(motion.div)`
   margin-top: 16px;
@@ -38,12 +47,11 @@ const Container = styled(motion.div)`
   border-radius: 3px;
 `
 
-const Header = styled.div({
-  color: '#24292e',
-  backgroundColor: '#fafbfc',
-  padding: '10px',
-  height: '40px',
-})
+const Header = styled.div`
+  background-color: ${({ theme }) => theme.background};
+  padding: 10px;
+  height: 40px;
+`
 
 const DiffLoading = () => (
   <Container

--- a/src/components/common/Diff/DiffLoading.js
+++ b/src/components/common/Diff/DiffLoading.js
@@ -34,7 +34,7 @@ const DiffLoader = () => (
 
 const Container = styled(motion.div)`
   margin-top: 16px;
-  border: 1px solid #e8e8e8;
+  border: 1px solid ${({ theme }) => theme.border};
   border-radius: 3px;
 `
 

--- a/src/components/common/Diff/DiffSection.js
+++ b/src/components/common/Diff/DiffSection.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react'
+import { Typography } from 'antd'
 import styled from '@emotion/styled'
 import semver from 'semver'
 import Diff from './Diff'
@@ -7,7 +8,7 @@ export const testIDs = {
   diffSection: 'diffSection',
 }
 
-const Title = styled.h1`
+const Title = styled(Typography.Title)`
   margin-top: 0.5em;
 `
 
@@ -46,7 +47,9 @@ const DiffSection = ({
   return (
     <div data-testid={testIDs.diffSection}>
       {title && completedDiffs.length > 0 && (
-        <Title ref={doneTitleRef}>{title}</Title>
+        <Title ref={doneTitleRef} level={2}>
+          {title}
+        </Title>
       )}
 
       {diff.map((diffFile) => {

--- a/src/components/common/Diff/DiffViewStyleOptions.js
+++ b/src/components/common/Diff/DiffViewStyleOptions.js
@@ -32,7 +32,7 @@ const DiffViewStyleOptions = styled(
   &,
   &:hover,
   &:focus {
-    color: #24292e;
+    color: ${({ theme }) => theme.text};
   }
 `
 export default DiffViewStyleOptions

--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -28,7 +28,7 @@ const TopContainer = styled.div`
 
 const Link = styled.a`
   padding: 4px 15px;
-  color: #1677ff;
+  color: ${({ theme }) => theme.link};
 `
 
 const getDiffKey = ({ oldRevision, newRevision }) =>

--- a/src/components/common/Markdown.js
+++ b/src/components/common/Markdown.js
@@ -12,7 +12,7 @@ export const Link = styled((props) => (
   />
 ))`
   text-decoration: none;
-  color: #045dc1;
+  color: ${({ theme }) => theme.link};
 `
 
 const InlineCode = styled.em`

--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -31,6 +31,8 @@ const Settings = ({
   packageName,
   language,
   onChangePackageNameAndLanguage,
+  themeName,
+  handleThemeToggle,
 }) => {
   const [popoverVisibility, setVisibility] = useState(false)
   const [newPackageName, setNewPackageName] = useState(packageName)
@@ -58,6 +60,8 @@ const Settings = ({
 
   const updateCheckboxValues = (checkboxValues) =>
     handleSettingsChange(checkboxValues)
+
+  const humanThemeName = themeName[0].toUpperCase() + themeName.substring(1)
 
   return (
     <Popover
@@ -102,6 +106,10 @@ const Settings = ({
               </PackagesGroupContainer>
             </Radio.Group>
           </PlatformsContainer>
+          <h5>Theme:</h5>
+          <Button title={humanThemeName} onClick={handleThemeToggle}>
+            {humanThemeName}
+          </Button>
         </>
       }
       trigger="click"

--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -31,8 +31,6 @@ const Settings = ({
   packageName,
   language,
   onChangePackageNameAndLanguage,
-  isDarkMode,
-  toggleDarkMode,
 }) => {
   const [popoverVisibility, setVisibility] = useState(false)
   const [newPackageName, setNewPackageName] = useState(packageName)
@@ -104,10 +102,6 @@ const Settings = ({
               </PackagesGroupContainer>
             </Radio.Group>
           </PlatformsContainer>
-          <h5>Theme:</h5>
-          <Button onClick={toggleDarkMode}>
-            {isDarkMode ? 'Dark' : 'Light'}
-          </Button>
         </>
       }
       trigger="click"

--- a/src/components/common/Settings.js
+++ b/src/components/common/Settings.js
@@ -31,8 +31,8 @@ const Settings = ({
   packageName,
   language,
   onChangePackageNameAndLanguage,
-  themeName,
-  handleThemeToggle,
+  isDarkMode,
+  toggleDarkMode,
 }) => {
   const [popoverVisibility, setVisibility] = useState(false)
   const [newPackageName, setNewPackageName] = useState(packageName)
@@ -60,8 +60,6 @@ const Settings = ({
 
   const updateCheckboxValues = (checkboxValues) =>
     handleSettingsChange(checkboxValues)
-
-  const humanThemeName = themeName[0].toUpperCase() + themeName.substring(1)
 
   return (
     <Popover
@@ -107,8 +105,8 @@ const Settings = ({
             </Radio.Group>
           </PlatformsContainer>
           <h5>Theme:</h5>
-          <Button title={humanThemeName} onClick={handleThemeToggle}>
-            {humanThemeName}
+          <Button onClick={toggleDarkMode}>
+            {isDarkMode ? 'Dark' : 'Light'}
           </Button>
         </>
       }

--- a/src/components/common/TroubleshootingGuides.js
+++ b/src/components/common/TroubleshootingGuides.js
@@ -20,7 +20,7 @@ const Container = styled(motion.div)`
 
 const Content = styled(motion.div)`
   h4 {
-    border-bottom: 1px solid #e8e8e8;
+    border-bottom: 1px solid ${({ theme }) => theme.border};
     padding-bottom: 6px;
   }
 `

--- a/src/components/common/UpgradeSupportAlert.js
+++ b/src/components/common/UpgradeSupportAlert.js
@@ -25,10 +25,10 @@ const UpgradeSupportAlert = styled((props) => (
   </div>
 ))`
   span > a {
-    color: #045dc1;
+    color: ${({ theme }) => theme.link}};
 
     &:hover {
-      color: #40a9ff;
+      color: ${({ theme }) => theme.linkHover}};
     }
   }
 `

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -27,7 +27,7 @@ const InnerContainer = styled.div`
   background-color: #fffbe6;
   border-width: 1px;
   border-left-width: 7px;
-  border-color: #ffe58f;
+  border-color: ${({ theme }) => theme.yellowBorder};
   border-style: solid;
   border-radius: 3px;
   transition: padding 0.25s ease-out;

--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -18,13 +18,13 @@ import { PACKAGE_NAMES } from '../../constants'
 const Container = styled.div`
   position: relative;
   margin-top: 16px;
-  color: rgba(0, 0, 0, 0.65);
   overflow: hidden;
 `
 
 const InnerContainer = styled.div`
-  color: rgba(0, 0, 0, 0.65);
-  background-color: #fffbe6;
+  color: ${({ theme }) =>
+    theme.text + 'D9'}; // the D9 adds some transparency to the text color
+  background-color: ${({ theme }) => theme.yellowBackground};
   border-width: 1px;
   border-left-width: 7px;
   border-color: ${({ theme }) => theme.yellowBorder};
@@ -112,16 +112,12 @@ const HideContentButton = styled(
   border-width: 0px;
   width: 20px;
   height: 20px;
-  color: rgba(0, 0, 0, 0.45);
-  &:hover,
-  &:focus {
-    color: #24292e;
-  }
+  color: ${({ theme }) => theme.text + '73'}; // 45% opacity
 `
 
 const Separator = styled.hr`
   margin: 15px 0;
-  background-color: #e1e4e8;
+  background-color: ${({ theme }) => theme.border};
   height: 0.25em;
   border: 0;
 `

--- a/src/components/common/UsefulLinks.js
+++ b/src/components/common/UsefulLinks.js
@@ -6,7 +6,7 @@ import { PACKAGE_NAMES } from '../../constants'
 
 const Separator = styled.hr`
   margin: 15px 0;
-  background-color: #e1e4e8;
+  background-color: ${({ theme }) => theme.border};
   height: 0.25em;
   border: 0;
 `

--- a/src/components/common/ViewFileButton.js
+++ b/src/components/common/ViewFileButton.js
@@ -22,7 +22,6 @@ const ViewFileButton = styled(
   }
 )`
   font-size: 12px;
-  color: #24292e;
 `
 
 export default ViewFileButton

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useDeferredValue } from 'react'
 import styled from '@emotion/styled'
-import { ThemeProvider, Global, css } from '@emotion/react'
+import { ThemeProvider } from '@emotion/react'
 import { Card, Input, Typography, ConfigProvider, theme } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
@@ -194,16 +194,6 @@ const Home = () => {
     <ConfigProvider
       theme={{
         algorithm: isDarkMode ? darkAlgorithm : defaultAlgorithm,
-        // components: {
-        //   Button: {
-        //     // colorPrimary: '#00b96b',
-        //     algorithm: true, // Enable algorithm
-        //   },
-        //   Input: {
-        //     colorPrimary: '#eb2f96',
-        //     algorithm: true, // Enable algorithm
-        //   },
-        // },
       }}
     >
       <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -18,6 +18,7 @@ import {
   PACKAGE_NAMES,
 } from '../../constants'
 import { TroubleshootingGuidesButton } from '../common/TroubleshootingGuidesButton'
+import { DarkModeButton } from '../common/DarkModeButton'
 import { updateURL } from '../../utils/update-url'
 import { deviceSizes } from '../../utils/device-sizes'
 import { lightTheme, darkTheme } from '../../theme'
@@ -243,8 +244,10 @@ const Home = () => {
                     handlePackageNameAndLanguageChange
                   }
                   language={language}
+                />
+                <DarkModeButton
                   isDarkMode={isDarkMode}
-                  toggleDarkMode={toggleDarkMode}
+                  onClick={toggleDarkMode}
                 />
               </SettingsContainer>
             </HeaderContainer>

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useDeferredValue } from 'react'
 import styled from '@emotion/styled'
+import { ThemeProvider } from '@emotion/react'
 import { Card, Input, Typography } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
@@ -18,8 +19,10 @@ import {
 import { TroubleshootingGuidesButton } from '../common/TroubleshootingGuidesButton'
 import { updateURL } from '../../utils/update-url'
 import { deviceSizes } from '../../utils/device-sizes'
+import { lightTheme, darkTheme } from '../../theme'
 
 const Page = styled.div`
+  background-color: ${({ theme }) => theme.body};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -30,7 +33,7 @@ const Page = styled.div`
 const Container = styled(Card)`
   width: 90%;
   border-radius: 3px;
-  border-color: #e8e8e8;
+  border-color: ${({ theme }) => theme.border};
 `
 
 const HeaderContainer = styled.div`
@@ -181,95 +184,108 @@ const Home = () => {
     setSettings(normalizedIncomingSettings)
   }
 
+  const [themeName, setThemeName] = useState('light')
+  const themeToggler = () => {
+    themeName === 'light' ? setThemeName('dark') : setThemeName('light')
+  }
+
   return (
-    <Page>
-      <Container>
-        <HeaderContainer>
-          <TitleContainer>
-            <LogoImg
-              alt="React Native Upgrade Helper logo"
-              title="React Native Upgrade Helper logo"
-              src={logo}
-            />
-            <a href={homepageUrl}>
-              <TitleHeader>React Native Upgrade Helper</TitleHeader>
-            </a>
-          </TitleContainer>
+    <ThemeProvider theme={themeName === 'light' ? lightTheme : darkTheme}>
+      <Page>
+        <Container>
+          <HeaderContainer>
+            <TitleContainer>
+              <LogoImg
+                alt="React Native Upgrade Helper logo"
+                title="React Native Upgrade Helper logo"
+                src={logo}
+              />
+              <a href={homepageUrl}>
+                <TitleHeader>React Native Upgrade Helper</TitleHeader>
+              </a>
+            </TitleContainer>
 
-          <SettingsContainer>
-            <StarButton
-              href="https://github.com/react-native-community/upgrade-helper"
-              data-icon="octicon-star"
-              data-show-count="true"
-              aria-label="Star react-native-community/upgrade-helper on GitHub"
-            >
-              Star
-            </StarButton>
-            {packageName === PACKAGE_NAMES.RN && (
-              <TroubleshootingGuidesButton />
-            )}
-            <Settings
-              handleSettingsChange={handleSettingsChange}
-              packageName={packageName}
-              onChangePackageNameAndLanguage={
-                handlePackageNameAndLanguageChange
-              }
-              language={language}
-            />
-          </SettingsContainer>
-        </HeaderContainer>
+            <SettingsContainer>
+              <StarButton
+                href="https://github.com/react-native-community/upgrade-helper"
+                data-icon="octicon-star"
+                data-show-count="true"
+                aria-label="Star react-native-community/upgrade-helper on GitHub"
+              >
+                Star
+              </StarButton>
+              {packageName === PACKAGE_NAMES.RN && (
+                <TroubleshootingGuidesButton />
+              )}
+              <Settings
+                handleSettingsChange={handleSettingsChange}
+                packageName={packageName}
+                onChangePackageNameAndLanguage={
+                  handlePackageNameAndLanguageChange
+                }
+                language={language}
+                themeName={themeName}
+                handleThemeToggle={themeToggler}
+              />
+            </SettingsContainer>
+          </HeaderContainer>
 
-        <AppDetailsContainer>
-          <AppNameField>
-            <Typography.Title level={5}>What's your app name?</Typography.Title>
+          <AppDetailsContainer>
+            <AppNameField>
+              <Typography.Title level={5}>
+                What's your app name?
+              </Typography.Title>
 
-            <Input
-              size="large"
-              placeholder={DEFAULT_APP_NAME}
-              value={appName}
-              onChange={({ target }) => setAppName((value) => target.value)}
-            />
-          </AppNameField>
+              <Input
+                size="large"
+                placeholder={DEFAULT_APP_NAME}
+                value={appName}
+                onChange={({ target }) => setAppName((value) => target.value)}
+              />
+            </AppNameField>
 
-          <AppPackageField>
-            <Typography.Title level={5}>
-              What's your app package?
-            </Typography.Title>
+            <AppPackageField>
+              <Typography.Title level={5}>
+                What's your app package?
+              </Typography.Title>
 
-            <Input
-              size="large"
-              placeholder={DEFAULT_APP_PACKAGE}
-              value={appPackage}
-              onChange={({ target }) => setAppPackage((value) => target.value)}
-            />
-          </AppPackageField>
-        </AppDetailsContainer>
-        <VersionSelector
-          key={packageName}
-          showDiff={handleShowDiff}
-          showReleaseCandidates={settings[SHOW_LATEST_RCS]}
-          packageName={packageName}
-          language={language}
-          isPackageNameDefinedInURL={isPackageNameDefinedInURL}
-        />
-      </Container>
-      {/*
+              <Input
+                size="large"
+                placeholder={DEFAULT_APP_PACKAGE}
+                value={appPackage}
+                onChange={({ target }) =>
+                  setAppPackage((value) => target.value)
+                }
+              />
+            </AppPackageField>
+          </AppDetailsContainer>
+          <VersionSelector
+            key={packageName}
+            showDiff={handleShowDiff}
+            showReleaseCandidates={settings[SHOW_LATEST_RCS]}
+            packageName={packageName}
+            language={language}
+            isPackageNameDefinedInURL={isPackageNameDefinedInURL}
+          />
+        </Container>
+        {/*
         Pass empty values for app name and package if they're the defaults to 
         hint to diffing components they don't need to further patch the 
         rn-diff-purge output.
       */}
-      <DiffViewer
-        shouldShowDiff={shouldShowDiff}
-        fromVersion={fromVersion}
-        toVersion={toVersion}
-        appName={deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''}
-        appPackage={
-          deferredAppPackage !== DEFAULT_APP_PACKAGE ? deferredAppPackage : ''
-        }
-        packageName={packageName}
-        language={language}
-      />
-    </Page>
+        <DiffViewer
+          shouldShowDiff={shouldShowDiff}
+          fromVersion={fromVersion}
+          toVersion={toVersion}
+          appName={deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''}
+          appPackage={
+            deferredAppPackage !== DEFAULT_APP_PACKAGE ? deferredAppPackage : ''
+          }
+          packageName={packageName}
+          language={language}
+        />
+      </Page>
+    </ThemeProvider>
   )
 }
 

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@emotion/react'
 import { Card, Input, Typography, ConfigProvider, theme } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
+import createPersistedState from 'use-persisted-state'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
 import Settings from '../common/Settings'
@@ -114,6 +115,10 @@ const StarButton = styled(({ className, ...props }) => (
   margin-right: auto;
 `
 
+// Set up a persisted state hook for for dark mode so users coming back
+// will have dark mode automatically if they've selected it previously.
+const useDarkModeState = createPersistedState('darkMode')
+
 const Home = () => {
   const { packageName: defaultPackageName, isPackageNameDefinedInURL } =
     useGetPackageNameFromURL()
@@ -185,10 +190,17 @@ const Home = () => {
     setSettings(normalizedIncomingSettings)
   }
 
-  const { defaultAlgorithm, darkAlgorithm } = theme
-  const [isDarkMode, setIsDarkMode] = useState(false)
+  // Dark Mode Setup:
+  const { defaultAlgorithm, darkAlgorithm } = theme // Get default and dark mode states from antd.
+  const [isDarkMode, setIsDarkMode] = useDarkModeState(false) // Remembers dark mode state between sessions.
   const toggleDarkMode = () => setIsDarkMode((previousValue) => !previousValue)
   const themeString = isDarkMode ? 'dark' : 'light'
+  useEffect(() => {
+    // Set the document's background color to the theme's body color.
+    document.body.style.backgroundColor = isDarkMode
+      ? darkTheme.background
+      : lightTheme.background
+  }, [isDarkMode])
 
   return (
     <ConfigProvider

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useDeferredValue } from 'react'
 import styled from '@emotion/styled'
-import { ThemeProvider } from '@emotion/react'
-import { Card, Input, Typography } from 'antd'
+import { ThemeProvider, Global, css } from '@emotion/react'
+import { Card, Input, Typography, ConfigProvider, theme } from 'antd'
 import GitHubButton from 'react-github-btn'
 import ReactGA from 'react-ga'
 import VersionSelector from '../common/VersionSelector'
@@ -31,6 +31,7 @@ const Page = styled.div`
 `
 
 const Container = styled(Card)`
+  background-color: ${({ theme }) => theme.background};
   width: 90%;
   border-radius: 3px;
   border-color: ${({ theme }) => theme.border};
@@ -184,108 +185,129 @@ const Home = () => {
     setSettings(normalizedIncomingSettings)
   }
 
-  const [themeName, setThemeName] = useState('light')
-  const themeToggler = () => {
-    themeName === 'light' ? setThemeName('dark') : setThemeName('light')
-  }
+  const { defaultAlgorithm, darkAlgorithm } = theme
+  const [isDarkMode, setIsDarkMode] = useState(false)
+  const toggleDarkMode = () => setIsDarkMode((previousValue) => !previousValue)
+  const themeString = isDarkMode ? 'dark' : 'light'
 
   return (
-    <ThemeProvider theme={themeName === 'light' ? lightTheme : darkTheme}>
-      <Page>
-        <Container>
-          <HeaderContainer>
-            <TitleContainer>
-              <LogoImg
-                alt="React Native Upgrade Helper logo"
-                title="React Native Upgrade Helper logo"
-                src={logo}
-              />
-              <a href={homepageUrl}>
-                <TitleHeader>React Native Upgrade Helper</TitleHeader>
-              </a>
-            </TitleContainer>
+    <ConfigProvider
+      theme={{
+        algorithm: isDarkMode ? darkAlgorithm : defaultAlgorithm,
+        // components: {
+        //   Button: {
+        //     // colorPrimary: '#00b96b',
+        //     algorithm: true, // Enable algorithm
+        //   },
+        //   Input: {
+        //     colorPrimary: '#eb2f96',
+        //     algorithm: true, // Enable algorithm
+        //   },
+        // },
+      }}
+    >
+      <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+        <Page>
+          <Container>
+            <HeaderContainer>
+              <TitleContainer>
+                <LogoImg
+                  alt="React Native Upgrade Helper logo"
+                  title="React Native Upgrade Helper logo"
+                  src={logo}
+                />
+                <a href={homepageUrl}>
+                  <TitleHeader>React Native Upgrade Helper</TitleHeader>
+                </a>
+              </TitleContainer>
 
-            <SettingsContainer>
-              <StarButton
-                href="https://github.com/react-native-community/upgrade-helper"
-                data-icon="octicon-star"
-                data-show-count="true"
-                aria-label="Star react-native-community/upgrade-helper on GitHub"
-              >
-                Star
-              </StarButton>
-              {packageName === PACKAGE_NAMES.RN && (
-                <TroubleshootingGuidesButton />
-              )}
-              <Settings
-                handleSettingsChange={handleSettingsChange}
-                packageName={packageName}
-                onChangePackageNameAndLanguage={
-                  handlePackageNameAndLanguageChange
-                }
-                language={language}
-                themeName={themeName}
-                handleThemeToggle={themeToggler}
-              />
-            </SettingsContainer>
-          </HeaderContainer>
+              <SettingsContainer>
+                <StarButton
+                  href="https://github.com/react-native-community/upgrade-helper"
+                  data-icon="octicon-star"
+                  data-show-count="true"
+                  aria-label="Star react-native-community/upgrade-helper on GitHub"
+                  data-color-scheme={`no-preference: ${themeString}; light: ${themeString}; dark: ${themeString};`}
+                >
+                  Star
+                </StarButton>
+                {packageName === PACKAGE_NAMES.RN && (
+                  <TroubleshootingGuidesButton />
+                )}
+                <Settings
+                  handleSettingsChange={handleSettingsChange}
+                  packageName={packageName}
+                  onChangePackageNameAndLanguage={
+                    handlePackageNameAndLanguageChange
+                  }
+                  language={language}
+                  isDarkMode={isDarkMode}
+                  toggleDarkMode={toggleDarkMode}
+                />
+              </SettingsContainer>
+            </HeaderContainer>
 
-          <AppDetailsContainer>
-            <AppNameField>
-              <Typography.Title level={5}>
-                What's your app name?
-              </Typography.Title>
+            <AppDetailsContainer>
+              <AppNameField>
+                <Typography.Title level={5}>
+                  What's your app name?
+                </Typography.Title>
 
-              <Input
-                size="large"
-                placeholder={DEFAULT_APP_NAME}
-                value={appName}
-                onChange={({ target }) => setAppName((value) => target.value)}
-              />
-            </AppNameField>
+                <Input
+                  size="large"
+                  placeholder={DEFAULT_APP_NAME}
+                  value={appName}
+                  onChange={({ target }) => setAppName((value) => target.value)}
+                />
+              </AppNameField>
 
-            <AppPackageField>
-              <Typography.Title level={5}>
-                What's your app package?
-              </Typography.Title>
+              <AppPackageField>
+                <Typography.Title level={5}>
+                  What's your app package?
+                </Typography.Title>
 
-              <Input
-                size="large"
-                placeholder={DEFAULT_APP_PACKAGE}
-                value={appPackage}
-                onChange={({ target }) =>
-                  setAppPackage((value) => target.value)
-                }
-              />
-            </AppPackageField>
-          </AppDetailsContainer>
-          <VersionSelector
-            key={packageName}
-            showDiff={handleShowDiff}
-            showReleaseCandidates={settings[SHOW_LATEST_RCS]}
-            packageName={packageName}
-            language={language}
-            isPackageNameDefinedInURL={isPackageNameDefinedInURL}
-          />
-        </Container>
-        {/*
+                <Input
+                  size="large"
+                  placeholder={DEFAULT_APP_PACKAGE}
+                  value={appPackage}
+                  onChange={({ target }) =>
+                    setAppPackage((value) => target.value)
+                  }
+                />
+              </AppPackageField>
+            </AppDetailsContainer>
+            <VersionSelector
+              key={packageName}
+              showDiff={handleShowDiff}
+              showReleaseCandidates={settings[SHOW_LATEST_RCS]}
+              packageName={packageName}
+              language={language}
+              isPackageNameDefinedInURL={isPackageNameDefinedInURL}
+            />
+          </Container>
+          {/*
         Pass empty values for app name and package if they're the defaults to 
         hint to diffing components they don't need to further patch the 
         rn-diff-purge output.
       */}
-        <DiffViewer
-          shouldShowDiff={shouldShowDiff}
-          fromVersion={fromVersion}
-          toVersion={toVersion}
-          appName={deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''}
-          appPackage={
-            deferredAppPackage !== DEFAULT_APP_PACKAGE ? deferredAppPackage : ''
-          }
-          packageName={packageName}
-          language={language}
-        />
-      </Page>
-    </ThemeProvider>
+          <DiffViewer
+            shouldShowDiff={shouldShowDiff}
+            fromVersion={fromVersion}
+            toVersion={toVersion}
+            appName={
+              deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''
+            }
+            appPackage={
+              deferredAppPackage !== DEFAULT_APP_PACKAGE
+                ? deferredAppPackage
+                : ''
+            }
+            packageName={packageName}
+            language={language}
+          />
+        </Page>
+      </ThemeProvider>
+    </ConfigProvider>
   )
 }
 

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -33,6 +33,13 @@ export const lightTheme = {
   // Alternating Row Colors for Binary Download component
   rowEven: '#fafbfc',
   rowOdd: '#ffffff',
+
+  // The completed files counter
+  popover: {
+    background: '#d5eafd',
+    text: '#7dadda',
+    border: '#1890ff',
+  },
 }
 export const darkTheme = {
   body: '#363537',
@@ -68,4 +75,10 @@ export const darkTheme = {
   // Alternating Row Colors for Binary Download component
   rowEven: '#363537',
   rowOdd: '#222223',
+
+  popover: {
+    text: '#7dadda',
+    background: '#0E5699',
+    border: '#aabbca',
+  },
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,22 @@
+export const lightTheme = {
+  body: '#FFF',
+  //   text: '#363537',
+  //   toggleBorder: '#FFF',
+  //   background: '#363537',
+  border: '#e8e8e8',
+  greenBorder: '#bef5cb',
+  yellowBorder: '#ffe58f',
+  lightGreenBackground: '#cdffd8',
+  darkGreenBackground: '#acf2bd',
+}
+export const darkTheme = {
+  body: '#363537',
+  //   text: '#FAFAFA',
+  //   toggleBorder: '#6B8096',
+  //   background: '#999',
+  border: '#e8e8e8',
+  greenBorder: '#bef5cb',
+  yellowBorder: '#ffe58f',
+  lightGreenBackground: '#cdffd8',
+  darkGreenBackground: '#acf2bd',
+}

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -7,6 +7,7 @@ export const lightTheme = {
   border: '#e8e8e8',
   greenBorder: '#bef5cb',
   yellowBorder: '#ffe58f',
+  yellowBackground: '#fffbe6',
 
   diff: {
     decoration: '#dbedff',
@@ -40,7 +41,8 @@ export const darkTheme = {
   textHover: '#999',
   border: '#888',
   greenBorder: '#bef5cb',
-  yellowBorder: '#ffe58f',
+  yellowBorder: '#c69026',
+  yellowBackground: '#37332A',
 
   diff: {
     decoration: '#dbedff',

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,6 +1,8 @@
 export const lightTheme = {
   body: '#FFF',
-  //   text: '#363537',
+  background: '#ffffff',
+
+  text: '#363537',
   //   toggleBorder: '#FFF',
   //   background: '#363537',
   border: '#e8e8e8',
@@ -8,15 +10,22 @@ export const lightTheme = {
   yellowBorder: '#ffe58f',
   lightGreenBackground: '#cdffd8',
   darkGreenBackground: '#acf2bd',
+  // Alternating Rows
+  rowEven: '#fafbfc',
+  rowOdd: '#ffffff',
 }
 export const darkTheme = {
   body: '#363537',
-  //   text: '#FAFAFA',
+  background: '#363537',
+  text: '#FAFAFA',
   //   toggleBorder: '#6B8096',
   //   background: '#999',
-  border: '#e8e8e8',
+  border: '#888',
   greenBorder: '#bef5cb',
   yellowBorder: '#ffe58f',
   lightGreenBackground: '#cdffd8',
   darkGreenBackground: '#acf2bd',
+  // Alternating Rows
+  rowEven: '#363537',
+  rowOdd: '#363537',
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,9 +1,10 @@
 export const lightTheme = {
-  body: '#FFF',
   background: '#ffffff',
 
   text: '#363537',
   textHover: 'rgba(27, 31, 35, 0.6)',
+  link: '#045dc1',
+  linkHover: '#40a9ff',
   border: '#e8e8e8',
   greenBorder: '#bef5cb',
   yellowBorder: '#ffe58f',
@@ -42,10 +43,13 @@ export const lightTheme = {
   },
 }
 export const darkTheme = {
-  body: '#363537',
   background: '#363537',
+
   text: '#FAFAFA',
   textHover: '#999',
+  link: '#045dc1',
+  linkHover: '#40a9ff',
+
   border: '#888',
   greenBorder: '#bef5cb',
   yellowBorder: '#c69026',

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -40,35 +40,35 @@ export const lightTheme = {
   },
 }
 export const darkTheme = {
-  background: '#363537',
+  background: '#0d1117',
 
   text: '#FAFAFA',
   textHover: '#999999',
   link: '#045dc1',
   linkHover: '#40a9ff',
 
-  border: '#555555',
+  border: '#30363d',
   greenBorder: '#bef5cb',
   yellowBorder: '#c69026',
-  yellowBackground: '#37332A',
+  yellowBackground: '#37332a8a',
 
   diff: {
     // Color object from https://github.com/otakustay/react-diff-view/blob/master/site/components/DiffView/diff.global.less
     textColor: '#fafafa',
     selectionBackground: '#5a5f80',
-    gutterInsertBackground: '#082525',
-    gutterDeleteBackground: '#2b1523',
+    gutterInsertBackground: '#3fb9504d',
+    gutterDeleteBackground: '#f8514c4d',
     gutterSelectedBackground: '#5a5f80',
-    codeInsertBackground: '#082525',
-    codeDeleteBackground: '#2b1523',
-    codeInsertEditBackground: '#00462f',
-    codeDeleteEditBackground: '#4e2436',
+    codeInsertBackground: '#2ea04326',
+    codeDeleteBackground: '#f851491a',
+    codeInsertEditBackground: '#2ea04366',
+    codeDeleteEditBackground: '#f8514c66',
     codeSelectedBackground: '#5a5f80',
     omitBackground: '#101120',
     decorationGutterBackground: '#222',
-    decorationGutter: '#ababab',
-    decorationContentBackground: '#222',
-    decorationContent: '#ababab',
+    decorationGutter: '#388bfd66',
+    decorationContentBackground: '#388bfd1a',
+    decorationContent: '#7d8590',
   },
 
   // Alternating Row Colors for Binary Download component and Content Loader animation

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -3,14 +3,33 @@ export const lightTheme = {
   background: '#ffffff',
 
   text: '#363537',
-  //   toggleBorder: '#FFF',
-  //   background: '#363537',
+  textHover: 'rgba(27, 31, 35, 0.6)',
   border: '#e8e8e8',
   greenBorder: '#bef5cb',
   yellowBorder: '#ffe58f',
-  lightGreenBackground: '#cdffd8',
-  darkGreenBackground: '#acf2bd',
-  // Alternating Rows
+
+  diff: {
+    decoration: '#dbedff',
+
+    // Color object from https://github.com/otakustay/react-diff-view/blob/master/site/components/DiffView/diff.global.less
+    textColor: '#000',
+    selectionBackground: '#b3d7ff',
+    gutterInsertBackground: '#cdffd8',
+    gutterDeleteBackground: '#fadde0',
+    gutterSelectedBackground: '#fffce0',
+    codeInsertBackground: '#eaffee',
+    codeDeleteBackground: '#fdeff0',
+    codeInsertEditBackground: '#acf2bd',
+    codeDeleteEditBackground: '#f39ea2',
+    codeSelectedBackground: '#fffce0',
+    omitBackground: '#fafbfc',
+    decorationGutterBackground: '#dbedff',
+    decorationGutter: '#999',
+    decorationContentBackground: '#dbedff',
+    decorationContent: '#999',
+  },
+
+  // Alternating Row Colors for Binary Download component
   rowEven: '#fafbfc',
   rowOdd: '#ffffff',
 }
@@ -18,14 +37,33 @@ export const darkTheme = {
   body: '#363537',
   background: '#363537',
   text: '#FAFAFA',
-  //   toggleBorder: '#6B8096',
-  //   background: '#999',
+  textHover: '#999',
   border: '#888',
   greenBorder: '#bef5cb',
   yellowBorder: '#ffe58f',
-  lightGreenBackground: '#cdffd8',
-  darkGreenBackground: '#acf2bd',
-  // Alternating Rows
+
+  diff: {
+    decoration: '#dbedff',
+
+    // Color object from https://github.com/otakustay/react-diff-view/blob/master/site/components/DiffView/diff.global.less
+    textColor: '#fafafa',
+    selectionBackground: '#5a5f80',
+    gutterInsertBackground: '#082525',
+    gutterDeleteBackground: '#2b1523',
+    gutterSelectedBackground: '#5a5f80',
+    codeInsertBackground: '#082525',
+    codeDeleteBackground: '#2b1523',
+    codeInsertEditBackground: '#00462f',
+    codeDeleteEditBackground: '#4e2436',
+    codeSelectedBackground: '#5a5f80',
+    omitBackground: '#101120',
+    decorationGutterBackground: '#222',
+    decorationGutter: '#ababab',
+    decorationContentBackground: '#222',
+    decorationContent: '#ababab',
+  },
+
+  // Alternating Row Colors for Binary Download component
   rowEven: '#363537',
-  rowOdd: '#363537',
+  rowOdd: '#222223',
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,5 +1,5 @@
 export const lightTheme = {
-  background: '#ffffff',
+  background: '#FFFFFF',
 
   text: '#363537',
   textHover: 'rgba(27, 31, 35, 0.6)',
@@ -11,9 +11,6 @@ export const lightTheme = {
   yellowBackground: '#fffbe6',
 
   diff: {
-    decoration: '#dbedff',
-
-    // Color object from https://github.com/otakustay/react-diff-view/blob/master/site/components/DiffView/diff.global.less
     textColor: '#000',
     selectionBackground: '#b3d7ff',
     gutterInsertBackground: '#cdffd8',
@@ -31,9 +28,9 @@ export const lightTheme = {
     decorationContent: '#999',
   },
 
-  // Alternating Row Colors for Binary Download component
-  rowEven: '#fafbfc',
-  rowOdd: '#ffffff',
+  // Alternating Row Colors for Binary Download component and Content Loader animation
+  rowEven: '#EEEEEE',
+  rowOdd: '#FFFFFF',
 
   // The completed files counter
   popover: {
@@ -46,18 +43,16 @@ export const darkTheme = {
   background: '#363537',
 
   text: '#FAFAFA',
-  textHover: '#999',
+  textHover: '#999999',
   link: '#045dc1',
   linkHover: '#40a9ff',
 
-  border: '#888',
+  border: '#555555',
   greenBorder: '#bef5cb',
   yellowBorder: '#c69026',
   yellowBackground: '#37332A',
 
   diff: {
-    decoration: '#dbedff',
-
     // Color object from https://github.com/otakustay/react-diff-view/blob/master/site/components/DiffView/diff.global.less
     textColor: '#fafafa',
     selectionBackground: '#5a5f80',
@@ -76,10 +71,11 @@ export const darkTheme = {
     decorationContent: '#ababab',
   },
 
-  // Alternating Row Colors for Binary Download component
+  // Alternating Row Colors for Binary Download component and Content Loader animation
   rowEven: '#363537',
   rowOdd: '#222223',
 
+  // The completed files counter
   popover: {
     text: '#7dadda',
     background: '#0E5699',


### PR DESCRIPTION
# Summary

This implements a dark mode toggle in the settings popover.

I was on a plane and had the upgrade helper open working on an upgrade and the brightness of the app was blinding me in a dark plane cabin. So I decided to work on implementing a dark mode toggle button. Hopefully this closes #97.

This was a two-fold approach using the included `antd` library's `ConfigProvider` to automatically control the colors of most buttons and text,  and `@emotion/react`'s `ThemeProvider` and `useTheme()` hook. The ThemeProvider also gave us access to style the components using `styled` CSS. I switched a few components over to `antd` to make them style automatically.

There is a new theme file included with two objects that should mirror each other and transferred over a lot of the existing colors for light mode and then used Github's darkmode as inspiration to fill out the dark mode object. I'm completely open to changing these colors if someone with a lot more design sense wants to weigh in.

Part of the theme object is `theme.diff` which lays out the colors for the html generated by `react-diff-view`. They have [an example of darkmode colors in their example code](https://github.com/otakustay/react-diff-view/blob/master/site/components/DiffView/diff.global.less), but it's commented out and it seems like [they won't be implementing a dark mode in their library](https://github.com/otakustay/react-diff-view/issues/144).

From that object, I applied the color overrides that had already been established (our dark green is a little nicer than the one from the library)

I've done my best to ensure that almost all instances of hard coded colors have been replaced by an entry in the theme file but i may have missed some places. 

The dependencies already include `use-persisted-state` so i used that library to remember the user's choice of dark mode or not across browser sessions.

## Test Plan

### Here's a quick demo of the changes:

![111B64AC-6833-43E9-B50F-AD62750F20AE-61572-000057CBE390DF60](https://github.com/react-native-community/upgrade-helper/assets/139261/1d6e2914-490a-4f69-8628-0415fbf40b67)

### And some screenshots:

#### Full Page:

![Screenshot 2023-12-01 at 1 21 13 PM](https://github.com/react-native-community/upgrade-helper/assets/139261/ffed3100-cc9d-449f-b845-3551ffa4eae2)

#### Done Section: 

![Screenshot 2023-12-01 at 1 21 27 PM](https://github.com/react-native-community/upgrade-helper/assets/139261/2b0d5a3a-d381-4041-9e38-48b39a3e4daa)

#### Binary Downloads:

![Screenshot 2023-12-01 at 1 22 06 PM](https://github.com/react-native-community/upgrade-helper/assets/139261/79b9a34d-16b3-4520-8996-26b2deae95ef)

#### Inline Comments: 

![Screenshot 2023-12-01 at 1 22 31 PM](https://github.com/react-native-community/upgrade-helper/assets/139261/1e0e0640-775f-4bfc-afc5-b988d9c31b71)


## Checklist

- [x] One place to change all colors in the app.
- [x] Dark mode toggle switch in the settings panel.
- [x] Remembers your dark mode preference across web browser sessions
- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
