### PR TITLE
Fix package name and app name replacement

### DIFF
--- a/src/components/common/Diff/Diff.tsx
+++ b/src/components/common/Diff/Diff.tsx
@@ -272,13 +272,17 @@ const Diff = ({
     toVersion,
   })
 
-  const updatedHunks = React.useMemo(() => getHunksWithAppName(hunks), [hunks])
+  const updatedHunks = React.useMemo(
+    () => getHunksWithAppName(hunks),
+    [hunks, getHunksWithAppName]
+  )
+
   const tokens: HunkTokens = React.useMemo(
     () =>
-      tokenize(hunks, {
+      tokenize(updatedHunks, {
         enhancers: [markEdits(updatedHunks)],
       }),
-    [hunks, updatedHunks]
+    [updatedHunks]
   )
 
   return (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

the app name and package name were not being properly changed inside the diff files, only in the diff path, this is happening because the tokenizer is using the old `hunks` instead of `updatedHunks`. I also added `getHunksWithAppName` as a dependency to make sure the files are automatically updated when the app name or package name are changed. This isn't introducing any new features, simply fixing what appears to be a bug.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
### Before:
![image](https://github.com/react-native-community/upgrade-helper/assets/43501040/d87729e8-c2c5-4e41-9d3d-b2093bfedd5e)
### After:

![image](https://github.com/react-native-community/upgrade-helper/assets/43501040/9426f133-2971-464d-8719-6a012acd4037)


## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
