### PR TITLE
Fix duplicate hunks when using updated hunks list

### DIFF
--- a/src/components/common/Diff/Diff.tsx
+++ b/src/components/common/Diff/Diff.tsx
@@ -272,7 +272,10 @@ const Diff = ({
     toVersion,
   })
 
-  const updatedHunks = React.useMemo(() => getHunksWithAppName(hunks), [hunks])
+  const updatedHunks: HunkData[] = React.useMemo(
+    () => getHunksWithAppName(hunks),
+    [hunks]
+  )
   const tokens: HunkTokens = React.useMemo(
     () =>
       tokenize(hunks, {
@@ -323,21 +326,21 @@ const Diff = ({
           selectedChanges={selectedChanges}
         >
           {(hunks: HunkData[]) =>
-            hunks.map((hunk) => (
-              <Fragment key={hunk.content}>
-                {updatedHunks.map((hunk) => [
+            hunks
+              .map((_, i) => updatedHunks[i])
+              .map((hunk) => (
+                <Fragment key={hunk.content}>
                   <Decoration key={'decoration-' + hunk.content}>
                     <More>{hunk.content}</More>
-                  </Decoration>,
+                  </Decoration>
                   <Hunk
                     key={hunk.content}
                     hunk={hunk}
                     // @ts-ignore-next-line
                     gutterEvents={{ onClick: onToggleChangeSelection }}
-                  />,
-                ])}
-              </Fragment>
-            ))
+                  />
+                </Fragment>
+              ))
           }
         </DiffView>
       )}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I just took a stab at what I think is causing #377, it'd be useful to get some eyes to validate why we were originally mapping each list of `hunks` to `updatedHunks`.  Here's the current state:

![CleanShot 2024-02-26 at 15 56 15@2x](https://github.com/react-native-community/upgrade-helper/assets/49578/835d4ae6-483a-48c8-a289-84bbb4c749da)


After the change:

![CleanShot 2024-02-26 at 16 05 45@2x](https://github.com/react-native-community/upgrade-helper/assets/49578/4091dccc-5899-4872-87e4-ca622c881134)


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`yarn start`

## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
