### PR TITLE
Fix issue with AppName stripping incorrectly.

### DIFF
--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -2,6 +2,7 @@ import { PACKAGE_NAMES } from '../constants'
 import '../releases/__mocks__/index'
 import {
   getVersionsContentInDiff,
+  removeAppPathPrefix,
   replaceAppDetails,
   getChangelogURL,
 } from '../utils'
@@ -131,4 +132,22 @@ describe('replaceAppDetails ', () => {
       expect(replaceAppDetails(path, appName, appPackage)).toEqual(newPath)
     }
   )
+})
+
+describe('removeAppPathPrefix', () => {
+  test.each([
+    ['RnDiffApp/package.json', 'package.json'],
+    ['RnDiffApp/RnDiffApp.ts', 'RnDiffApp.ts'],
+  ])('removeAppPathPrefix("%s") -> "%s"', (path, newPath) => {
+    expect(removeAppPathPrefix(path)).toEqual(newPath)
+  })
+
+  test('removeAppPathPrefix custom AppName', () => {
+    expect(removeAppPathPrefix('RnDiffApp/package.json', '')).toEqual(
+      'RnDiffApp/package.json'
+    )
+    expect(removeAppPathPrefix('Foobar/package.json', 'Foobar')).toEqual(
+      'package.json'
+    )
+  })
 })

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useDeferredValue } from 'react'
+import React, { useState, useEffect, useReducer, useDeferredValue } from 'react'
 import styled from '@emotion/styled'
 import { ThemeProvider } from '@emotion/react'
 import { Card, Input, Typography, ConfigProvider, theme } from 'antd'
@@ -125,6 +125,12 @@ const StarButton = styled(({ className, ...props }: StarButtonProps) => (
 // will have dark mode automatically if they've selected it previously.
 const useDarkModeState = createPersistedState('darkMode')
 
+// The value returns to `defaultValue` when an empty string is entered,
+// this makes our down-tree props behaviour simpler without having to swap
+// empty values for the default.
+const useDefaultState = (defaultValue: string) =>
+  useReducer((_, v: string) => (v === '' ? defaultValue : v), defaultValue)
+
 const Home = () => {
   const { packageName: defaultPackageName, isPackageNameDefinedInURL } =
     useGetPackageNameFromURL()
@@ -138,8 +144,8 @@ const Home = () => {
     [`${SHOW_LATEST_RCS}`]: false,
   })
 
-  const [appName, setAppName] = useState<string>('')
-  const [appPackage, setAppPackage] = useState<string>('')
+  const [appName, setAppName] = useDefaultState(DEFAULT_APP_NAME)
+  const [appPackage, setAppPackage] = useDefaultState(DEFAULT_APP_PACKAGE)
 
   // Avoid UI lag when typing.
   const deferredAppName = useDeferredValue(appName)
@@ -276,8 +282,8 @@ const Home = () => {
                 <Input
                   size="large"
                   placeholder={DEFAULT_APP_NAME}
-                  value={appName}
-                  onChange={({ target }) => setAppName((value) => target.value)}
+                  value={appName === DEFAULT_APP_NAME ? '' : appName}
+                  onChange={({ target }) => setAppName(target.value)}
                 />
               </AppNameField>
 
@@ -289,10 +295,8 @@ const Home = () => {
                 <Input
                   size="large"
                   placeholder={DEFAULT_APP_PACKAGE}
-                  value={appPackage}
-                  onChange={({ target }) =>
-                    setAppPackage((value) => target.value)
-                  }
+                  value={appPackage === DEFAULT_APP_PACKAGE ? '' : appPackage}
+                  onChange={({ target }) => setAppPackage(target.value)}
                 />
               </AppPackageField>
             </AppDetailsContainer>
@@ -315,14 +319,8 @@ const Home = () => {
             shouldShowDiff={shouldShowDiff}
             fromVersion={fromVersion}
             toVersion={toVersion}
-            appName={
-              deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''
-            }
-            appPackage={
-              deferredAppPackage !== DEFAULT_APP_PACKAGE
-                ? deferredAppPackage
-                : ''
-            }
+            appName={deferredAppName}
+            appPackage={deferredAppPackage}
             packageName={packageName}
             language={language}
           />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ export const getBinaryFileURL = ({
 }
 
 export const removeAppPathPrefix = (path: string, appName = DEFAULT_APP_NAME) =>
-  path.replace(new RegExp(`${appName}/`), '')
+  path.replace(new RegExp(`^${appName}/`), '')
 
 /**
  * Replaces DEFAULT_APP_PACKAGE and DEFAULT_APP_NAME in str with custom


### PR DESCRIPTION
Handles cases where appName wasn't playing nicely with it's default value.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The `appName` is meant to be stripped off in various places.  When setting the default, the actual value passed around is `''`.  This change does 2 things:

1. makes regex stricter to only match against prefixes, and
2. passes the default `appName` down the tree when an empty string is inputted.

## Before
![CleanShot 2024-02-26 at 16 05 45@2x](https://github.com/react-native-community/upgrade-helper/assets/49578/b3f4c9cb-b26e-49a8-837d-1cc678215a32)

## After

https://github.com/react-native-community/upgrade-helper/assets/49578/5b467ea7-2415-4879-a40b-4bf4cbeb701d



<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`yarn start`

## What are the steps to reproduce?

You can see it live.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
