### PR TITLE
feat: add package and name to URL params

### DIFF
--- a/src/components/common/VersionSelector.tsx
+++ b/src/components/common/VersionSelector.tsx
@@ -229,12 +229,16 @@ const VersionSelector = ({
   isPackageNameDefinedInURL,
   showDiff,
   showReleaseCandidates,
+  appPackage,
+  appName,
 }: {
   packageName: string
   language: string
   isPackageNameDefinedInURL: boolean
   showDiff: (args: { fromVersion: string; toVersion: string }) => void
   showReleaseCandidates: boolean
+  appPackage: string
+  appName: string
 }) => {
   const { isLoading, isDone, releaseVersions } = useFetchReleaseVersions({
     packageName,
@@ -363,6 +367,8 @@ const VersionSelector = ({
       isPackageNameDefinedInURL,
       fromVersion: localFromVersion,
       toVersion: localToVersion,
+      appPackage,
+      appName,
     })
   }
 

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -5,6 +5,7 @@ import { Card, Input, Typography, ConfigProvider, theme } from 'antd'
 import GitHubButton, { ReactGitHubButtonProps } from 'react-github-btn'
 import ReactGA from 'react-ga'
 import createPersistedState from 'use-persisted-state'
+import queryString from 'query-string'
 import VersionSelector from '../common/VersionSelector'
 import DiffViewer from '../common/DiffViewer'
 import Settings from '../common/Settings'
@@ -107,6 +108,19 @@ const SettingsContainer = styled.div`
   flex: 1;
 `
 
+const getAppInfoInURL = (): {
+  appPackage: string
+  appName: string
+} => {
+  // Parses `/?name=RnDiffApp&package=com.rndiffapp` from URL
+  const { name, package: pkg } = queryString.parse(window.location.search)
+
+  return {
+    appPackage: pkg as string,
+    appName: name as string,
+  }
+}
+
 interface StarButtonProps extends ReactGitHubButtonProps {
   className?: string
 }
@@ -138,8 +152,9 @@ const Home = () => {
     [`${SHOW_LATEST_RCS}`]: false,
   })
 
-  const [appName, setAppName] = useState<string>('')
-  const [appPackage, setAppPackage] = useState<string>('')
+  const appInfoInURL = getAppInfoInURL()
+  const [appName, setAppName] = useState<string>(appInfoInURL.appName)
+  const [appPackage, setAppPackage] = useState<string>(appInfoInURL.appPackage)
 
   // Avoid UI lag when typing.
   const deferredAppName = useDeferredValue(appName)
@@ -303,6 +318,8 @@ const Home = () => {
               packageName={packageName}
               language={language}
               isPackageNameDefinedInURL={isPackageNameDefinedInURL}
+              appPackage={appPackage}
+              appName={appName}
             />
           </Container>
           {/*

--- a/src/utils/update-url.ts
+++ b/src/utils/update-url.ts
@@ -6,12 +6,16 @@ export function updateURL({
   isPackageNameDefinedInURL,
   fromVersion,
   toVersion,
+  appPackage,
+  appName,
 }: {
   packageName: string
   language: string
   isPackageNameDefinedInURL: boolean
   fromVersion: string
   toVersion: string
+  appPackage: string
+  appName: string
 }) {
   const url = new URL(window.location.origin)
   url.pathname = window.location.pathname
@@ -28,6 +32,12 @@ export function updateURL({
   }
   if (packageName === PACKAGE_NAMES.RNW) {
     url.searchParams.set('language', language)
+  }
+  if (appPackage) {
+    url.searchParams.set('package', appPackage)
+  }
+  if (appName) {
+    url.searchParams.set('name', appName)
   }
 
   window.history.replaceState(null, '', url.toString())


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
- Closes #373
- Allows for the user to provide query params for `package` and `name` in addition to the existing to/from versions
- Query param values are sent to the input boxes as the default value
- URL is updated when user updates the `What's your app name?` and `What's your app package?` inputs
- Closely follows the same way the version params worked

## Test Plan

https://github.com/react-native-community/upgrade-helper/assets/374022/befd4d31-9bde-400d-91ff-bf9ee4bcc3e9

> [!IMPORTANT] 
> While testing, I did notice there were parts of the source code that did not receive anything but the placeholder value for the app package identifier `com.rndiffapp`. This mostly seemed isolated to the Android diffs, where `package` or `namespace` is set.
>
> Opened another issue with this info @ #382 



## What are the steps to reproduce?

1. Initially add query params to the url, such as `http://localhost:3000/?package=com.test.app&name=MyApp`
- _Observe that the form contains the passed in values_
- _Observe that the `Show me how to upgrade!` result incorporates these values_

2. Update the inputs (package and/or name) using the form and press `Show me how to upgrade!`
- _Observe that the URL updates accordingly_

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] ~I added the documentation in `README.md` (if needed)~
