### PR TITLE
feat: add comments to diff for React Native 0.74

### DIFF
--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -3,6 +3,7 @@ import { PACKAGE_NAMES } from '../constants'
 const versionsWithContent = {
   [PACKAGE_NAMES.RN]: [
     '0.73',
+    '0.74',
     '0.72',
     '0.71',
     '0.69',

--- a/src/releases/react-native/0.74.tsx
+++ b/src/releases/react-native/0.74.tsx
@@ -1,0 +1,35 @@
+import React, { Fragment } from 'react'
+import type { ReleaseT } from '../types'
+
+const release: ReleaseT = {
+  usefulContent: {
+    description:
+      'React Native 0.74 includes Yoga 3.0, Bridgeless by default under the New Architecture, batched onLayout updates, Yarn 3, removal of previously deprecated PropTypes, and some breaking changes, including updates to PushNotificationIOS. The Android Minimum SDK is now 23 (Android 6.0).',
+    links: [
+      {
+        title:
+          'Official blog post about the major changes on React Native 0.74',
+        url: 'https://reactnative.dev/blog/2024/04/22/release-0.74',
+      },
+    ],
+  },
+  comments: [
+    {
+      fileName: '.yarnrc',
+      lineNumber: 3,
+      lineChangeType: 'add',
+      content: (
+        <Fragment>
+          In React Native 0.74, for projects bootstrapped with React Native
+          Community CLI, we've added first-class support for modern Yarn
+          versions. For new projects Yarn 3.6.4 is the default package manager,
+          and for existing projects, you can upgrade to Yarn 3.6.4 by running
+          `yarn set version berry` in the project root. Read more
+          [here](https://reactnative.dev/blog/2024/04/22/release-0.74#yarn-3-for-new-projects).
+        </Fragment>
+      ),
+    },
+  ],
+}
+
+export default release

--- a/src/releases/react-native/0.74.tsx
+++ b/src/releases/react-native/0.74.tsx
@@ -15,8 +15,8 @@ const release: ReleaseT = {
   },
   comments: [
     {
-      fileName: '.yarnrc',
-      lineNumber: 3,
+      fileName: 'package.json',
+      lineNumber: 36,
       lineChangeType: 'add',
       content: (
         <Fragment>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

For new project created with React Native Community CLI, we'll try to bump Yarn version to `3.6.4` which is the supported and maintained one. For people that are upgrading apps in my opinion it's very important to say what this diff means, and how they should handle it inside exciting projects. 

Builds on top of: https://github.com/react-native-community/rn-diff-purge/pull/75


## Test Plan

Get diff from this PR https://github.com/react-native-community/rn-diff-purge/pull/75 and check if the comment is shown properly in right place. 

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [x] I added the documentation in `README.md` (if needed)
