### PR TITLE
UI improvements

### DIFF
--- a/src/components/common/AlignDepsAlert.tsx
+++ b/src/components/common/AlignDepsAlert.tsx
@@ -8,11 +8,13 @@ const AlignDepsAlert = () => (
       @rnx-kit/align-deps --requirements react-native@[major.minor]`.
     </Markdown>
     <br />
+    <br />
     <Markdown>
-      `align-deps` is an OSS tool from Microsoft that automates dependency
-      management. It knows which packages\* versions are compatible with your
-      specific version of RN, and it uses that knowledge to align dependencies,
-      keeping your app healthy and up-to-date\*\*. [Find out more
+      [`align-deps`](https://microsoft.github.io/rnx-kit/docs/tools/align-deps)
+      is an OSS tool from Microsoft that automates dependency management. It
+      knows which packages\* versions are compatible with your specific version
+      of RN, and it uses that knowledge to align dependencies, keeping your app
+      healthy and up-to-date\*\*. [Find out more
       here](https://microsoft.github.io/rnx-kit/docs/guides/dependency-management).
     </Markdown>
     <br />

--- a/src/components/common/Diff/Diff.tsx
+++ b/src/components/common/Diff/Diff.tsx
@@ -21,7 +21,7 @@ import type { ChangeEventArgs } from 'react-diff-view'
 import type { DefaultRenderToken } from 'react-diff-view/types/context'
 
 const copyPathPopoverContentOpts = {
-  default: 'Click to copy file path',
+  default: 'Copy file path',
   copied: 'File path copied!',
 }
 

--- a/src/components/common/Diff/DiffHeader.tsx
+++ b/src/components/common/Diff/DiffHeader.tsx
@@ -131,12 +131,18 @@ interface CompleteDiffButtonProps extends ButtonProps {
 }
 
 const CompleteDiffButton = styled(
-  ({ open, onClick, ...props }: CompleteDiffButtonProps) =>
-    open ? (
-      <Button {...props} icon={<RollbackOutlined />} onClick={onClick} />
-    ) : (
-      <Button {...props} icon={<CheckOutlined />} onClick={onClick} />
-    )
+  ({ open, onClick, ...props }: CompleteDiffButtonProps) => (
+    <Popover
+      content={open ? 'Mark as not viewed' : 'Mark as viewed'}
+      trigger="hover"
+    >
+      {open ? (
+        <Button {...props} icon={<RollbackOutlined />} onClick={onClick} />
+      ) : (
+        <Button {...props} icon={<CheckOutlined />} onClick={onClick} />
+      )}
+    </Popover>
+  )
 )`
   ${defaultIconButtonStyle}
   &,
@@ -171,7 +177,7 @@ const CopyPathToClipboardButton = styled(
         content={copyPathPopoverContent}
         trigger="hover"
         overlayStyle={{
-          width: '175px',
+          width: '140px',
           textAlign: 'center',
         }}
       >
@@ -188,7 +194,7 @@ const CopyPathToClipboardButton = styled(
 `
 
 const copyAnchorLinks = {
-  default: 'Click to copy anchor link',
+  default: 'Copy anchor link',
   copied: 'Anchor link copied!',
 }
 
@@ -199,6 +205,7 @@ interface CopyAnchorLinksToClipboardButtonProps
   toVersion: string
   type: string
 }
+
 const CopyAnchorLinksToClipboardButton = styled(
   ({
     id,
@@ -226,7 +233,7 @@ const CopyAnchorLinksToClipboardButton = styled(
           content={content}
           trigger="hover"
           overlayStyle={{
-            width: '175px',
+            width: '150px',
             textAlign: 'center',
           }}
         >
@@ -244,12 +251,17 @@ const CopyAnchorLinksToClipboardButton = styled(
 `
 
 const CollapseClickableArea = styled.div`
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+
   &:hover {
     cursor: pointer;
   }
-`
 
+  & > *:last-child {
+    margin-left: 8px;
+  }
+`
 interface CollapseDiffButtonProps extends ButtonProps {
   open: boolean
   isDiffCollapsed: boolean
@@ -258,10 +270,15 @@ interface CollapseDiffButtonProps extends ButtonProps {
 
 const CollapseDiffButton = styled(
   ({ open, isDiffCollapsed, ...props }: CollapseDiffButtonProps) =>
-    open ? <Button {...props} type="link" icon={<DownOutlined />} /> : null
+    open ? (
+      <Button
+        {...props}
+        type="link"
+        icon={<DownOutlined style={{ height: 12, width: 12 }} />}
+      />
+    ) : null
 )`
   color: ${({ theme }) => theme.text};
-  margin-right: 2px;
   font-size: 10px;
   transform: ${({ isDiffCollapsed }) =>
     isDiffCollapsed ? 'rotate(-90deg)' : 'initial'};
@@ -343,7 +360,7 @@ const DiffHeader = ({
             oldPath={sanitizedFilePaths.oldPath}
             newPath={sanitizedFilePaths.newPath}
             type={type}
-          />{' '}
+          />
           <FileStatus type={type} />
           <BinaryBadge open={!hasDiff} />
         </CollapseClickableArea>
@@ -354,14 +371,13 @@ const DiffHeader = ({
           onCopy={onCopyPathToClipboard}
           copyPathPopoverContent={copyPathPopoverContent}
           resetCopyPathPopoverContent={resetCopyPathPopoverContent}
-        />
+        />{' '}
         <CopyAnchorLinksToClipboardButton
           id={id}
           type={type}
           fromVersion={fromVersion}
           toVersion={toVersion}
         />
-
         <DiffCommentReminder
           comments={diffComments}
           isDiffCollapsed={isDiffCollapsed}
@@ -388,7 +404,7 @@ const DiffHeader = ({
           version={toVersion}
           path={newPath}
           packageName={packageName}
-        />
+        />{' '}
         <CompleteDiffButton
           open={isDiffCompleted}
           onClick={() => onCompleteDiff(diffKey)}

--- a/src/components/common/UpgradeButton.tsx
+++ b/src/components/common/UpgradeButton.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
 `
 
 const Button = styled(AntdButton)`
-  border-radius: 3px;
+  border-radius: 5px;
 `
 
 interface UpgradeButtonProps extends React.PropsWithRef<ButtonProps> {

--- a/src/components/common/UpgradeSupportAlert.tsx
+++ b/src/components/common/UpgradeSupportAlert.tsx
@@ -30,10 +30,6 @@ const UpgradeSupportAlert = styled((props: UpgradeSupportAlertProps) => (
 ))`
   span > a {
     color: ${({ theme }) => theme.link}};
-
-    &:hover {
-      color: ${({ theme }) => theme.linkHover}};
-    }
   }
 `
 

--- a/src/components/common/UsefulContentSection.tsx
+++ b/src/components/common/UsefulContentSection.tsx
@@ -122,7 +122,13 @@ const HideContentButton = styled(
     <Button
       {...props}
       type="link"
-      icon={isContentOpen ? <UpOutlined /> : <DownOutlined />}
+      icon={
+        isContentOpen ? (
+          <UpOutlined style={{ height: 14, width: 14 }} />
+        ) : (
+          <DownOutlined style={{ height: 14, width: 14 }} />
+        )
+      }
       onClick={toggleContentVisibility}
     />
   )

--- a/src/components/common/VersionSelector.tsx
+++ b/src/components/common/VersionSelector.tsx
@@ -18,20 +18,14 @@ export const testIDs = {
 const Selectors = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 15px;
+  gap: 16px;
 
   @media ${deviceSizes.tablet} {
     flex-direction: row;
-    gap: 0;
   }
 `
 
-const FromVersionSelector = styled(Select)`
-  @media ${deviceSizes.tablet} {
-    padding-right: 5px;
-  }
-`
+const FromVersionSelector = styled(Select)``
 
 interface ToVersionSelectorProps extends SelectProps {
   popover?: React.ReactNode
@@ -47,11 +41,7 @@ const ToVersionSelector = styled(
     ) : (
       <Select {...props} />
     )
-)`
-  @media ${deviceSizes.tablet} {
-    padding-left: 5px;
-  }
-`
+)``
 
 const getVersionsInURL = (): {
   fromVersion: string

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -73,29 +73,19 @@ const TitleContainer = styled.div`
 
 const AppNameField = styled.div`
   width: 100%;
-
-  @media ${deviceSizes.tablet} {
-    padding-right: 5px;
-  }
 `
 
 const AppPackageField = styled.div`
   width: 100%;
-
-  @media ${deviceSizes.tablet} {
-    padding-left: 5px;
-  }
 `
 
 const AppDetailsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 15px;
+  gap: 16px;
 
   @media ${deviceSizes.tablet} {
     flex-direction: row;
-    gap: 0;
   }
 `
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

PR addresses minor UI inconsistencies since the UI appears slightly off.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <body>
<tr>
      <td><img src="https://github.com/user-attachments/assets/d4a4cbdb-3efc-4680-a40f-36e81a758ed2" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/11a84219-16d6-451a-9d6b-06b140891704" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/65b8b7d6-5470-4b44-ba12-b702014ce3a5" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/30597c87-a7b8-4b82-aa0c-613a567b216b" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/6d3967a8-740e-4529-97ad-7e8613478185" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/b150c14d-01a0-4e8a-8b93-2c69cc68eacd" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/4cae7e77-700b-4c59-a102-1966bec0e449" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/85247094-eed8-4387-af4c-f54711112c86" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/cc1b269d-e48a-4eb2-ad67-8898f85b4574" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/9db3708b-3bcd-4b5d-8d4d-5894d7f409b5" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/6b04cf31-8c19-4151-9df4-d9c091276ba7" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/2a8cf03d-881d-4ed8-a08a-35a619d406cf" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/d7748a0f-232b-44ca-830e-112e851e35ca" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/bb2cc98c-1e37-4634-8070-e2f84b694f46" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/8a8ccab2-2143-41b5-9765-d5ed6ccae750" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/fed5555a-decd-420b-aa1d-7c1aed59d05a" alt="After" /></td>
    </tr>
  </tbody>
</table>

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
