### PR TITLE
fix: correctly replace app name in file path

### DIFF
--- a/src/components/common/VersionSelector.tsx
+++ b/src/components/common/VersionSelector.tsx
@@ -228,7 +228,7 @@ const VersionSelector = ({
   showDiff: (args: { fromVersion: string; toVersion: string }) => void
   showReleaseCandidates: boolean
   appPackage: string
-  appName: string
+  appName?: string
 }) => {
   const { isLoading, isDone, releaseVersions } = useFetchReleaseVersions({
     packageName,

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -98,16 +98,13 @@ const SettingsContainer = styled.div`
   flex: 1;
 `
 
-const getAppInfoInURL = (): {
-  appPackage: string
-  appName: string
-} => {
+const getAppInfoInURL = () => {
   // Parses `/?name=RnDiffApp&package=com.rndiffapp` from URL
   const { name, package: pkg } = queryString.parse(window.location.search)
 
   return {
     appPackage: pkg as string,
-    appName: name as string,
+    appName: name as string | null,
   }
 }
 
@@ -143,11 +140,11 @@ const Home = () => {
   })
 
   const appInfoInURL = getAppInfoInURL()
-  const [appName, setAppName] = useState<string>(appInfoInURL.appName)
-  const [appPackage, setAppPackage] = useState<string>(appInfoInURL.appPackage)
+  const [appName, setAppName] = useState(appInfoInURL.appName)
+  const [appPackage, setAppPackage] = useState(appInfoInURL.appPackage)
 
   // Avoid UI lag when typing.
-  const deferredAppName = useDeferredValue(appName)
+  const deferredAppName = useDeferredValue(appName || DEFAULT_APP_NAME)
   const deferredAppPackage = useDeferredValue(appPackage)
 
   const homepageUrl = process.env.PUBLIC_URL
@@ -281,7 +278,7 @@ const Home = () => {
                 <Input
                   size="large"
                   placeholder={DEFAULT_APP_NAME}
-                  value={appName}
+                  value={appName || ''}
                   onChange={({ target }) => setAppName((value) => target.value)}
                 />
               </AppNameField>
@@ -322,9 +319,7 @@ const Home = () => {
             shouldShowDiff={shouldShowDiff}
             fromVersion={fromVersion}
             toVersion={toVersion}
-            appName={
-              deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''
-            }
+            appName={deferredAppName}
             appPackage={
               deferredAppPackage !== DEFAULT_APP_PACKAGE
                 ? deferredAppPackage

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -278,7 +278,7 @@ const Home = () => {
                 <Input
                   size="large"
                   placeholder={DEFAULT_APP_NAME}
-                  value={appName || ''}
+                  value={appName ?? ''}
                   onChange={({ target }) => setAppName((value) => target.value)}
                 />
               </AppNameField>

--- a/src/utils/update-url.ts
+++ b/src/utils/update-url.ts
@@ -15,7 +15,7 @@ export function updateURL({
   fromVersion: string
   toVersion: string
   appPackage: string
-  appName: string
+  appName?: string
 }) {
   const url = new URL(window.location.origin)
   url.pathname = window.location.pathname


### PR DESCRIPTION
# Summary

Fixed an issue causing file paths to lose the first slash when using `RnDiffApp` as app name or an empty string after editing the input. A similar fix might need to be applied to `appPackage`, but I refrained from doing so to avoid potential side effects on any underlying component, as the value can be nullable.

<img width="675" alt="Screenshot 2025-02-27 at 18 10 05" src="https://github.com/user-attachments/assets/5b2e02c0-08fe-4564-a02c-521aa7df35bd" />

I know there was already #379 open, but we used this fix in [our fork](https://github.com/backstage/upgrade-helper) and we thought it was good to contribute upstream. Feel free to ignore this PR if another fix is more suitable 😊
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## What are the steps to reproduce?


1. Type: `RnDiffApp` in the app name input
2. Press "Show me how to upgrade!"
3. You will see that the path of each file is wrong.

or

1. Type anything in the app name input
2. Clear the app name input
3. Press "Show me how to upgrade!"
4. You will see that the path of each file is wrong.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
