### PR TITLE
Add warning for AppDelegate.mm on RN 0.77

### DIFF
--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -2,6 +2,7 @@ import { PACKAGE_NAMES } from '../constants'
 
 const versionsWithContent = {
   [PACKAGE_NAMES.RN]: [
+    '0.77',
     '0.73',
     '0.74',
     '0.72',

--- a/src/releases/react-native/0.77.tsx
+++ b/src/releases/react-native/0.77.tsx
@@ -1,0 +1,22 @@
+import Markdown from '../../components/common/Markdown'
+import type { ReleaseT } from '../types'
+const release: ReleaseT = {
+  usefulContent: {
+    description: (
+      <Markdown>
+        React Native 0.77 changes the AppDelegate template from Obj-C++ to
+        Swift, but it's not only a syntax change. If you stick with the
+        `AppDelegate.mm` file, be sure to add the new line with
+        `RCTAppDependencyProvider`, as explained in the blog post below.
+      </Markdown>
+    ),
+    links: [
+      {
+        title: 'React Native 0.77 blog post',
+        url: 'https://reactnative.dev/blog/2025/01/21/version-0.77#rctappdependencyprovider',
+      },
+    ],
+  },
+}
+
+export default release

--- a/src/releases/types.d.ts
+++ b/src/releases/types.d.ts
@@ -4,7 +4,7 @@ interface ReleaseLinkT {
 }
 
 interface ReleaseUsefulContentT {
-  description: string
+  description: string | React.ReactNode
   links: ReleaseLinkT[]
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR adds a warning to the "Useful Contents" section when upgrading to RN 0.77 or above.

The issue we're trying to warn is because on 0.77, the AppDelegate template was migrated from Obj-C++ to Swift, but it is not only a syntax change. There were more lines added that, if the user decides to stick with the `AppDelegate.mm` version - and I imagine most people with existing apps will do - will pass unnoticed, since the diff just shows that the Obj-C++ file was deleted.

The message calls this out, and points to the blog post where the core team highlight the needed change.

Posted about it here: https://x.com/thiagobrez/status/1908101612838572473

![CleanShot 2025-04-04 at 17 06 03](https://github.com/user-attachments/assets/63666d90-bd37-4220-954f-7bfd5401e3e2)


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Going from any version below 0.77.0, to any version above 0.77.0, should show this message.

## What are the steps to reproduce?

Select FROM 0.76.9 TO 0.77.0, or any other combination as explained above.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I tested this thoroughly
- [X] I added the documentation in `README.md` (if needed)
