### PR TITLE
feat: add React Native 0.76 support

### DIFF
--- a/src/__tests__/releases/index.spec.ts
+++ b/src/__tests__/releases/index.spec.ts
@@ -1,0 +1,56 @@
+import releases from '../../releases/index'
+import { PACKAGE_NAMES } from '../../constants'
+
+describe('Releases index', () => {
+  it('should include React Native 0.76 in the versions list', () => {
+    const rnReleases = releases[PACKAGE_NAMES.RN]
+    expect(rnReleases).toBeDefined()
+    expect(Array.isArray(rnReleases)).toBe(true)
+
+    const version076 = rnReleases.find((release) => release.version === '0.76')
+    expect(version076).toBeDefined()
+    expect(version076?.usefulContent).toBeDefined()
+    expect(version076?.usefulContent.description).toBeDefined()
+    expect(version076?.usefulContent.links).toBeDefined()
+    expect(Array.isArray(version076?.usefulContent.links)).toBe(true)
+  })
+
+  it('should load React Native 0.76 release content correctly', () => {
+    const rnReleases = releases[PACKAGE_NAMES.RN]
+    const version076 = rnReleases.find((release) => release.version === '0.76')
+
+    expect(version076).toBeDefined()
+    expect(version076?.usefulContent.links).toHaveLength(2)
+
+    const blogPostLink = version076?.usefulContent.links.find(
+      (link) =>
+        link.title ===
+        'Official blog post about the major changes on React Native 0.76'
+    )
+    expect(blogPostLink?.url).toBe(
+      'https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture'
+    )
+
+    const newArchLink = version076?.usefulContent.links.find(
+      (link) => link.title === 'New Architecture documentation'
+    )
+    expect(newArchLink?.url).toBe(
+      'https://reactnative.dev/docs/the-new-architecture/landing-page'
+    )
+  })
+
+  it('should maintain proper version ordering with 0.76 included', () => {
+    const rnReleases = releases[PACKAGE_NAMES.RN]
+    const versions = rnReleases.map((release) => release.version)
+
+    expect(versions).toContain('0.76')
+    expect(versions).toContain('0.77')
+    expect(versions).toContain('0.74')
+
+    // 0.76 should be positioned between 0.77 and other versions
+    const index076 = versions.indexOf('0.76')
+    const index077 = versions.indexOf('0.77')
+    expect(index076).toBeGreaterThan(-1)
+    expect(index077).toBeGreaterThan(-1)
+  })
+})

--- a/src/__tests__/releases/react-native-0.76.spec.ts
+++ b/src/__tests__/releases/react-native-0.76.spec.ts
@@ -1,0 +1,43 @@
+import release from '../../releases/react-native/0.76'
+import type { ReleaseT } from '../../releases/types'
+
+describe('React Native 0.76 release configuration', () => {
+  it('should have the correct structure', () => {
+    expect(release).toBeDefined()
+    expect(typeof release).toBe('object')
+  })
+
+  it('should have usefulContent with description', () => {
+    expect(release.usefulContent).toBeDefined()
+    expect(release.usefulContent.description).toBeDefined()
+  })
+
+  it('should have useful links for 0.76 upgrade', () => {
+    expect(release.usefulContent.links).toBeDefined()
+    expect(Array.isArray(release.usefulContent.links)).toBe(true)
+    expect(release.usefulContent.links).toHaveLength(2)
+
+    const blogPostLink = release.usefulContent.links.find(
+      (link) =>
+        link.title ===
+        'Official blog post about the major changes on React Native 0.76'
+    )
+    expect(blogPostLink).toBeDefined()
+    expect(blogPostLink?.url).toBe(
+      'https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture'
+    )
+
+    const newArchLink = release.usefulContent.links.find(
+      (link) => link.title === 'New Architecture documentation'
+    )
+    expect(newArchLink).toBeDefined()
+    expect(newArchLink?.url).toBe(
+      'https://reactnative.dev/docs/the-new-architecture/landing-page'
+    )
+  })
+
+  it('should conform to ReleaseT type', () => {
+    const releaseAsType: ReleaseT = release
+    expect(releaseAsType).toBeDefined()
+  })
+})

--- a/src/releases/index.js
+++ b/src/releases/index.js
@@ -3,6 +3,7 @@ import { PACKAGE_NAMES } from '../constants'
 const versionsWithContent = {
   [PACKAGE_NAMES.RN]: [
     '0.77',
+    '0.76',
     '0.73',
     '0.74',
     '0.72',

--- a/src/releases/react-native/0.76.tsx
+++ b/src/releases/react-native/0.76.tsx
@@ -1,0 +1,21 @@
+import type { ReleaseT } from '../types'
+
+const release: ReleaseT = {
+  usefulContent: {
+    description:
+      "React Native 0.76 enables the New Architecture by default, which is a significant architectural change. This version includes over 1,491 commits from 165 contributors and introduces important changes that may affect your app's compatibility. Make sure to thoroughly test your application and review the New Architecture documentation.",
+    links: [
+      {
+        title:
+          'Official blog post about the major changes on React Native 0.76',
+        url: 'https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture',
+      },
+      {
+        title: 'New Architecture documentation',
+        url: 'https://reactnative.dev/docs/the-new-architecture/landing-page',
+      },
+    ],
+  },
+}
+
+export default release


### PR DESCRIPTION
## Summary
- Fixes missing React Native 0.76 support in upgrade helper
- Adds 0.76 release metadata with New Architecture documentation
- Includes comprehensive test coverage for the new release

## Test plan
- [x] Unit tests for 0.76 release file structure
- [x] Integration tests for releases index
- [x] All existing tests continue to pass
- [x] Linting and formatting checks pass