### PR TITLE
ci: upload hidden files

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: ./**
+          include-hidden-files: true
 
   install:
     needs: setup

--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -1,8 +1,12 @@
 interface Window {}
 
-interface Process {
-  env: {
-    PUBLIC_URL: string
-    NODE_ENV: 'development' | 'production'
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      PUBLIC_URL: string
+      NODE_ENV: 'development' | 'production'
+    }
   }
 }
+
+export {}

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -24,6 +24,7 @@ import { DarkModeButton } from '../common/DarkModeButton'
 import { updateURL } from '../../utils/update-url'
 import { deviceSizes } from '../../utils/device-sizes'
 import { lightTheme, darkTheme, type Theme } from '../../theme'
+import { CheckboxValueType } from 'antd/es/checkbox/Group'
 
 const Page = styled.div<{ theme?: Theme }>`
   background-color: ${({ theme }) => theme.background};
@@ -104,7 +105,7 @@ const getAppInfoInURL = () => {
 
   return {
     appPackage: pkg as string,
-    appName: name as string | null,
+    appName: name as string | undefined,
   }
 }
 
@@ -198,9 +199,11 @@ const Home = () => {
     setShouldShowDiff(false)
   }
 
-  const handleSettingsChange = (settingsValues: string[]) => {
-    const normalizedIncomingSettings = settingsValues.reduce((acc, val) => {
-      acc[val] = true
+  const handleSettingsChange = (settingsValues: CheckboxValueType[]) => {
+    const normalizedIncomingSettings = settingsValues.reduce<
+      Record<string, boolean>
+    >((acc, val) => {
+      acc[String(val)] = true
       return acc
     }, {})
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -20,7 +20,12 @@ const isLocalhost = Boolean(
     )
 )
 
-export function register(config) {
+interface ServiceWorkerConfig {
+  onSuccess?: (registration: ServiceWorkerRegistration) => void
+  onUpdate?: (registration: ServiceWorkerRegistration) => void
+}
+
+export function register(config?: ServiceWorkerConfig) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href)
@@ -54,7 +59,7 @@ export function register(config) {
   }
 }
 
-function registerValidSW(swUrl, config) {
+function registerValidSW(swUrl: string, config?: ServiceWorkerConfig) {
   navigator.serviceWorker
     .register(swUrl)
     .then((registration) => {
@@ -98,7 +103,7 @@ function registerValidSW(swUrl, config) {
     })
 }
 
-function checkValidServiceWorker(swUrl, config) {
+function checkValidServiceWorker(swUrl: string, config?: ServiceWorkerConfig) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then((response) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,9 +115,15 @@ export const getVersionsContentInDiff = ({
   }
 
   const cleanedToVersion = semver.valid(semver.coerce(toVersion))
+  if (!cleanedToVersion) {
+    return []
+  }
 
   return versions[packageName].filter(({ version }) => {
     const cleanedVersion = semver.coerce(version)
+    if (!cleanedVersion) {
+      return false
+    }
 
     // `cleanedVersion` can't be newer than `cleanedToVersion` nor older (or equal) than `fromVersion`
     return (

--- a/src/utils/update-url.ts
+++ b/src/utils/update-url.ts
@@ -14,7 +14,7 @@ export function updateURL({
   isPackageNameDefinedInURL: boolean
   fromVersion: string
   toVersion: string
-  appPackage: string
+  appPackage?: string
   appName?: string
 }) {
   const url = new URL(window.location.origin)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
       "module": "commonjs"
     }
   },
-  "include": ["./src", "./assets"],
+  "include": ["./src", "./assets", "./@types"],
   "exclude": ["./src/__tests__/*"]
 }


### PR DESCRIPTION
# Summary

Another tiny PR to add a missing argument to the `actions/upload-artifact@v4` as it is not uploading hidden files, making the `yarn lint` script fail due to not finding the ESLint config.