### PR TITLE
Fix GitHub API compatibility issues causing 404 errors

### DIFF
--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -4,6 +4,7 @@ import {
   getVersionsContentInDiff,
   replaceAppDetails,
   getChangelogURL,
+  getDiffURL,
 } from '../utils'
 
 describe('getVersionsContentInDiff', () => {
@@ -68,6 +69,47 @@ describe('getChangelogURL', () => {
   ])('getChangelogURL("%s", "%s") -> %s', (packageName, version, url) => {
     expect(getChangelogURL({ packageName, version })).toEqual(url)
   })
+})
+
+describe('getDiffURL', () => {
+  const { RN, RNM, RNW } = PACKAGE_NAMES
+  test.each([
+    [
+      RN,
+      '',
+      '0.76.9',
+      '0.77.3',
+      'https://api.github.com/repos/react-native-community/rn-diff-purge/contents/diffs/0.76.9..0.77.3.diff?ref=diffs',
+    ],
+    [
+      RN,
+      '',
+      '0.70.0',
+      '0.71.0',
+      'https://api.github.com/repos/react-native-community/rn-diff-purge/contents/diffs/0.70.0..0.71.0.diff?ref=diffs',
+    ],
+    [
+      RNM,
+      '',
+      '0.70.0',
+      '0.71.0',
+      'https://api.github.com/repos/acoates-ms/rnw-diff/contents/diffs/mac/0.70.0..0.71.0.diff?ref=diffs',
+    ],
+    [
+      RNW,
+      'cpp',
+      '0.70.0',
+      '0.71.0',
+      'https://api.github.com/repos/acoates-ms/rnw-diff/contents/diffs/cpp/0.70.0..0.71.0.diff?ref=diffs',
+    ],
+  ])(
+    'getDiffURL("%s", "%s", "%s", "%s") -> %s',
+    (packageName, language, fromVersion, toVersion, expectedUrl) => {
+      expect(
+        getDiffURL({ packageName, language, fromVersion, toVersion })
+      ).toEqual(expectedUrl)
+    }
+  )
 })
 
 describe('replaceAppDetails ', () => {

--- a/src/hooks/fetch-diff.ts
+++ b/src/hooks/fetch-diff.ts
@@ -31,14 +31,24 @@ export const useFetchDiff = ({
       setIsLoading(true)
       setIsDone(false)
 
-      const [response] = await Promise.all([
-        fetch(getDiffURL({ packageName, language, fromVersion, toVersion })),
-        delay(300),
-      ])
+      try {
+        const [response] = await Promise.all([
+          fetch(getDiffURL({ packageName, language, fromVersion, toVersion })),
+          delay(300),
+        ])
 
-      const diff = await response.text()
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
 
-      setDiff(movePackageJsonToTop(parseDiff(diff)))
+        const data = await response.json()
+        const diff = atob(data.content)
+
+        setDiff(movePackageJsonToTop(parseDiff(diff)))
+      } catch (error) {
+        console.error('Failed to fetch diff:', error)
+        setDiff([])
+      }
 
       setIsLoading(false)
       setIsDone(true)

--- a/src/hooks/fetch-release-versions.ts
+++ b/src/hooks/fetch-release-versions.ts
@@ -16,8 +16,9 @@ export const useFetchReleaseVersions = ({
       setIsDone(false)
 
       const response = await fetch(getReleasesFileURL({ packageName }))
+      const apiResponse = await response.json()
 
-      const releaseVersions = (await response.text())
+      const releaseVersions = atob(apiResponse.content)
         .split('\n')
         .filter(Boolean)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,11 @@ const getRNDiffRepository = ({ packageName }: { packageName: string }) =>
   RN_DIFF_REPOSITORIES[packageName]
 
 export const getReleasesFileURL = ({ packageName }: { packageName: string }) =>
-  `https://raw.githubusercontent.com/${getRNDiffRepository({
+  `https://api.github.com/repos/${getRNDiffRepository({
     packageName,
-  })}/master/${packageName === PACKAGE_NAMES.RNM ? 'RELEASES_MAC' : 'RELEASES'}`
+  })}/contents/${
+    packageName === PACKAGE_NAMES.RNM ? 'RELEASES_MAC' : 'RELEASES'
+  }`
 
 export const getDiffURL = ({
   packageName,
@@ -34,9 +36,9 @@ export const getDiffURL = ({
       ? `${language}/`
       : ''
 
-  return `https://raw.githubusercontent.com/${getRNDiffRepository({
+  return `https://api.github.com/repos/${getRNDiffRepository({
     packageName,
-  })}/diffs/diffs/${languageDir}${fromVersion}..${toVersion}.diff`
+  })}/contents/diffs/${languageDir}${fromVersion}..${toVersion}.diff?ref=diffs`
 }
 
 const getBranch = ({


### PR DESCRIPTION
# Summary

This PR fixes compatibility issues with changes to GitHub's API that were causing 404 errors when fetching release versions and diff files.

**What issues does the pull request solve?**
- Fixes 404 errors when fetching React Native release versions from `https://raw.githubusercontent.com/react-native-community/rn-diff-purge/master/RELEASES`
- Resolves similar issues with GitHub's diff API endpoints when fetching upgrade diffs

**How was the solution implemented?**
- Updated `getReleasesFileURL` and `getDiffURL` to use GitHub's Contents API (`https://api.github.com/repos/.../contents/...`) instead of raw file URLs
- Modified the fetch logic in `useFetchReleaseVersions` and `useFetchDiff` to handle GitHub API JSON responses and decode base64-encoded content
- Added proper error handling for failed API requests in diff fetching
- Added comprehensive test coverage for the `getDiffURL` function with various package types and configurations

**What areas of the website does it impact?**
- Release version fetching functionality 
- Diff generation and display features
- Any components that depend on React Native version data

## Test Plan

**Manual Testing:**
1. Started development server with `npm start` - ✅ Compiled successfully
2. Verified API endpoints directly:
   ```bash
   # Release versions API
   curl -s "https://api.github.com/repos/react-native-community/rn-diff-purge/contents/RELEASES"
   
   # Diff files API
   curl -s "https://api.github.com/repos/react-native-community/rn-diff-purge/contents/diffs/0.76.9..0.77.3.diff?ref=diffs"
   ```
   Both return proper JSON with base64-encoded content
3. Decoded content to verify format matches expected structure

**Code Quality:**
- ✅ TypeScript compilation passes: `npm run typecheck`
- ✅ Linting passes: `npm run lint`
- ✅ All existing tests pass
- ✅ Added comprehensive tests for `getDiffURL` function covering React Native, React Native macOS, and React Native Windows packages

## What are the steps to reproduce?

**Before fix:**
1. Load the upgrade helper website
2. Try to fetch release versions or generate a diff
3. See 404 errors in console: `GET https://raw.githubusercontent.com/.../RELEASES 404 (Not Found)`

**After fix:**
1. Load the upgrade helper website  
2. Release versions and diffs load successfully via GitHub Contents API
3. No 404 errors in console

## Checklist

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)

## Note

"Raw" and "Copy raw contents" button still doesn't work